### PR TITLE
fix: skip harvest of a single resource if conflict from another source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -329,6 +329,12 @@
                         </configuration>
                     </execution>
                 </executions>
+                <configuration>
+                    <jvmTarget>${java.release}</jvmTarget>
+                    <compilerPlugins>
+                        <plugin>spring</plugin>
+                    </compilerPlugins>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/src/main/kotlin/no/fdk/fdk_harvester/harvester/ConceptHarvester.kt
+++ b/src/main/kotlin/no/fdk/fdk_harvester/harvester/ConceptHarvester.kt
@@ -3,22 +3,24 @@ package no.fdk.fdk_harvester.harvester
 import no.fdk.fdk_harvester.adapter.DefaultOrganizationsAdapter
 import no.fdk.fdk_harvester.config.ApplicationProperties
 import no.fdk.fdk_harvester.kafka.ResourceEventProducer
-import no.fdk.fdk_harvester.model.*
-import no.fdk.fdk_harvester.rdf.*
+import no.fdk.fdk_harvester.model.FdkIdAndUri
+import no.fdk.fdk_harvester.model.HarvestDataSource
+import no.fdk.fdk_harvester.model.HarvestReport
+import no.fdk.fdk_harvester.model.HarvestSourceEntity
+import no.fdk.fdk_harvester.model.ResourceEntity
+import no.fdk.fdk_harvester.model.ResourceType
 import no.fdk.fdk_harvester.rdf.computeChecksum
-import no.fdk.fdk_harvester.harvester.formatNowWithOsloTimeZone
-import no.fdk.fdk_harvester.harvester.formatWithOsloTimeZone
+import no.fdk.fdk_harvester.rdf.createConceptCatalogRecordModel
+import no.fdk.fdk_harvester.rdf.createIdFromString
+import no.fdk.fdk_harvester.rdf.createRDFResponse
 import no.fdk.fdk_harvester.repository.HarvestSourceRepository
 import no.fdk.fdk_harvester.repository.ResourceRepository
-import no.fdk.harvest.DataType as HarvestDataType
 import org.apache.jena.rdf.model.Model
 import org.apache.jena.riot.Lang
-import org.slf4j.LoggerFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import java.util.*
-
-private val LOGGER = LoggerFactory.getLogger(ConceptHarvester::class.java)
+import no.fdk.harvest.DataType as HarvestDataType
 
 /** Harvests concept collections from a SKOS/RDF source and publishes concept events. */
 @Service
@@ -30,7 +32,12 @@ class ConceptHarvester(
     harvestSourceRepository: HarvestSourceRepository
 ) : BaseHarvester(harvestSourceRepository) {
 
-    fun harvestConceptCollection(source: HarvestDataSource, harvestDate: Calendar, forceUpdate: Boolean, runId: String): HarvestReport? =
+    fun harvestConceptCollection(
+        source: HarvestDataSource,
+        harvestDate: Calendar,
+        forceUpdate: Boolean,
+        runId: String
+    ): HarvestReport? =
         validateAndHarvest(source, harvestDate, forceUpdate, runId, "concept", requiresAcceptHeader = true)
 
     override fun updateDB(
@@ -52,8 +59,14 @@ class ConceptHarvester(
         } else null
 
         val collections = splitCollectionsFromRDF(harvested, concepts, sourceURL, organization)
-        val (updatedCollections, conceptUriToCollectionFdkUri) = updateCollections(collections, harvestDate, forceUpdate, harvestSource)
-        val updatedConcepts = updateConcepts(concepts, harvestDate, forceUpdate, runId, harvestSource, conceptUriToCollectionFdkUri)
+        val (updatedCollections, conceptUriToCollectionFdkUri) = updateCollections(
+            collections,
+            harvestDate,
+            forceUpdate,
+            harvestSource
+        )
+        val updatedConcepts =
+            updateConcepts(concepts, harvestDate, forceUpdate, runId, harvestSource, conceptUriToCollectionFdkUri)
 
         val removedConcepts = getConceptsRemovedThisHarvest(
             concepts.map { it.resourceURI },
@@ -127,22 +140,37 @@ class ConceptHarvester(
         return updatedConcepts
     }
 
-    private fun ConceptRDFModel.updateDBOs(harvestDate: Calendar, forceUpdate: Boolean, harvestSource: HarvestSourceEntity): ResourceEntity? {
-        val dbMeta = resourceRepository.findByIdOrNull(resourceURI)
-        validateSourceUrl(resourceURI, harvestSource, dbMeta)
-        val harvestedChecksum = computeChecksum(harvested)
-        return when {
-            dbMeta == null || dbMeta.removed || conceptHasChanges(dbMeta, harvestedChecksum) -> {
-                val updatedMeta = mapToResource(harvestDate, dbMeta, harvestedChecksum, harvestSource)
-                resourceRepository.save(updatedMeta)
-                updatedMeta
+    private fun ConceptRDFModel.updateDBOs(
+        harvestDate: Calendar,
+        forceUpdate: Boolean,
+        harvestSource: HarvestSourceEntity
+    ): ResourceEntity? {
+        try {
+            val dbMeta = resourceRepository.findByIdOrNull(resourceURI)
+            validateSourceUrl(resourceURI, harvestSource, dbMeta)
+            val harvestedChecksum = computeChecksum(harvested)
+            return when {
+                dbMeta == null || dbMeta.removed || conceptHasChanges(dbMeta, harvestedChecksum) -> {
+                    val updatedMeta = mapToResource(harvestDate, dbMeta, harvestedChecksum, harvestSource)
+                    resourceRepository.save(updatedMeta)
+                    updatedMeta
+                }
+
+                forceUpdate -> {
+                    val updatedMeta = dbMeta.copy(
+                        checksum = harvestedChecksum,
+                        modified = harvestDate.toInstant(),
+                        harvestSource = harvestSource
+                    )
+                    resourceRepository.save(updatedMeta)
+                    updatedMeta
+                }
+
+                else -> null
             }
-            forceUpdate -> {
-                val updatedMeta = dbMeta.copy(checksum = harvestedChecksum, modified = harvestDate.toInstant(), harvestSource = harvestSource)
-                resourceRepository.save(updatedMeta)
-                updatedMeta
-            }
-            else -> null
+        } catch (conflictError: HarvestSourceConflictException) {
+            logger.warn("Concept skipped due to conflict when harvesting {}: {}", harvestSource.uri, conflictError.message)
+            return null
         }
     }
 
@@ -162,7 +190,7 @@ class ConceptHarvester(
                 conceptUriToCollectionFdkUri.putIfAbsent(conceptURI, collectionFdkUri)
             }
         }
-        // Validate source ownership for all collections before filtering by change (avoids reporting 0 change when feed contains resources owned by another source)
+        // Validate source ownership for all collections before filtering by change
         collections.forEach { coll ->
             validateSourceUrl(coll.resourceURI, harvestSource, resourceRepository.findByIdOrNull(coll.resourceURI))
         }
@@ -171,14 +199,17 @@ class ConceptHarvester(
             .filter { forceUpdate || it.first.collectionHasChanges(it.second, computeChecksum(it.first.harvested)) }
             .map {
                 val dbMeta = it.second
-                validateSourceUrl(it.first.resourceURI, harvestSource, dbMeta)
                 val collectionChecksum = computeChecksum(it.first.harvested)
                 val collectionMeta = if (dbMeta == null || it.first.collectionHasChanges(dbMeta, collectionChecksum)) {
                     it.first.mapToResource(harvestDate, dbMeta, collectionChecksum, harvestSource)
                         .also { updatedMeta -> resourceRepository.save(updatedMeta) }
                 } else {
                     if (forceUpdate) {
-                        dbMeta.copy(checksum = collectionChecksum, modified = harvestDate.toInstant(), harvestSource = harvestSource)
+                        dbMeta.copy(
+                            checksum = collectionChecksum,
+                            modified = harvestDate.toInstant(),
+                            harvestSource = harvestSource
+                        )
                             .also { resourceRepository.save(it) }
                     } else {
                         dbMeta
@@ -248,7 +279,10 @@ class ConceptHarvester(
         if (dbMeta == null) true
         else harvestedChecksum != dbMeta.checksum
 
-    private fun getConceptsRemovedThisHarvest(concepts: List<String>, harvestSource: HarvestSourceEntity): List<ResourceEntity> =
+    private fun getConceptsRemovedThisHarvest(
+        concepts: List<String>,
+        harvestSource: HarvestSourceEntity
+    ): List<ResourceEntity> =
         resourceRepository.findAllByType(ResourceType.CONCEPT)
             .filter { it.harvestSource.id == harvestSource.id && !it.removed && !concepts.contains(it.uri) }
 }

--- a/src/main/kotlin/no/fdk/fdk_harvester/harvester/DataServiceHarvester.kt
+++ b/src/main/kotlin/no/fdk/fdk_harvester/harvester/DataServiceHarvester.kt
@@ -2,15 +2,19 @@ package no.fdk.fdk_harvester.harvester
 
 import no.fdk.fdk_harvester.config.ApplicationProperties
 import no.fdk.fdk_harvester.kafka.ResourceEventProducer
-import no.fdk.fdk_harvester.model.*
-import no.fdk.fdk_harvester.rdf.*
-import no.fdk.fdk_harvester.rdf.createDataServiceCatalogRecordModel
+import no.fdk.fdk_harvester.model.FdkIdAndUri
+import no.fdk.fdk_harvester.model.HarvestDataSource
+import no.fdk.fdk_harvester.model.HarvestReport
+import no.fdk.fdk_harvester.model.HarvestSourceEntity
+import no.fdk.fdk_harvester.model.ResourceEntity
+import no.fdk.fdk_harvester.model.ResourceType
 import no.fdk.fdk_harvester.rdf.computeChecksum
-import no.fdk.fdk_harvester.harvester.formatNowWithOsloTimeZone
-import no.fdk.fdk_harvester.harvester.formatWithOsloTimeZone
+import no.fdk.fdk_harvester.rdf.containsTriple
+import no.fdk.fdk_harvester.rdf.createDataServiceCatalogRecordModel
+import no.fdk.fdk_harvester.rdf.createIdFromString
+import no.fdk.fdk_harvester.rdf.createRDFResponse
 import no.fdk.fdk_harvester.repository.HarvestSourceRepository
 import no.fdk.fdk_harvester.repository.ResourceRepository
-import no.fdk.harvest.DataType as HarvestDataType
 import org.apache.jena.rdf.model.Model
 import org.apache.jena.rdf.model.ModelFactory
 import org.apache.jena.rdf.model.Resource
@@ -18,12 +22,10 @@ import org.apache.jena.rdf.model.Statement
 import org.apache.jena.riot.Lang
 import org.apache.jena.vocabulary.DCAT
 import org.apache.jena.vocabulary.RDF
-import org.slf4j.LoggerFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import java.util.*
-
-private val LOGGER = LoggerFactory.getLogger(DataServiceHarvester::class.java)
+import no.fdk.harvest.DataType as HarvestDataType
 
 /** Harvests DCAT data service catalogs from RDF and publishes dataservice events (with FDK catalog records in the graph). */
 @Service
@@ -34,7 +36,12 @@ class DataServiceHarvester(
     harvestSourceRepository: HarvestSourceRepository
 ) : BaseHarvester(harvestSourceRepository) {
 
-    fun harvestDataServiceCatalog(source: HarvestDataSource, harvestDate: Calendar, forceUpdate: Boolean, runId: String): HarvestReport? =
+    fun harvestDataServiceCatalog(
+        source: HarvestDataSource,
+        harvestDate: Calendar,
+        forceUpdate: Boolean,
+        runId: String
+    ): HarvestReport? =
         validateAndHarvest(source, harvestDate, forceUpdate, runId, "dataservice", requiresAcceptHeader = true)
 
     override fun updateDB(
@@ -52,28 +59,32 @@ class DataServiceHarvester(
         val updatedServices = mutableListOf<FdkIdAndUri>()
         val removedServices = mutableListOf<ResourceEntity>()
         val resourceGraphs = mutableMapOf<String, String>()
-        
+
         val catalogPairs = splitCatalogsFromRDF(harvested, sourceUrl)
             .map { Pair(it, resourceRepository.findByIdOrNull(it.resourceURI)) }
-        // Validate source ownership for all catalogs and services before filtering by change (avoids reporting 0 change when feed contains resources owned by another source)
+        // Validate source ownership for all catalogs before filtering by change
         catalogPairs.forEach { (catalog, _) ->
-            validateSourceUrl(catalog.resourceURI, harvestSource, resourceRepository.findByIdOrNull(catalog.resourceURI))
-            catalog.services.forEach { service ->
-                validateSourceUrl(service.resourceURI, harvestSource, resourceRepository.findByIdOrNull(service.resourceURI))
-            }
+            validateSourceUrl(
+                catalog.resourceURI,
+                harvestSource,
+                resourceRepository.findByIdOrNull(catalog.resourceURI)
+            )
         }
         catalogPairs
             .filter { forceUpdate || it.first.catalogHasChanges(it.second, computeChecksum(it.first.harvestedCatalog)) }
             .forEach {
                 val dbMeta = it.second
-                validateSourceUrl(it.first.resourceURI, harvestSource, dbMeta)
                 val catalogChecksum = computeChecksum(it.first.harvestedCatalog)
                 val catalogMeta = if (dbMeta == null || it.first.catalogHasChanges(dbMeta, catalogChecksum)) {
                     it.first.mapToResource(harvestDate, dbMeta, catalogChecksum, harvestSource)
                         .also { updatedMeta -> resourceRepository.save(updatedMeta) }
                 } else {
                     if (forceUpdate) {
-                        dbMeta.copy(checksum = catalogChecksum, modified = harvestDate.toInstant(), harvestSource = harvestSource)
+                        dbMeta.copy(
+                            checksum = catalogChecksum,
+                            modified = harvestDate.toInstant(),
+                            harvestSource = harvestSource
+                        )
                             .also { resourceRepository.save(it) }
                     } else {
                         dbMeta
@@ -81,27 +92,36 @@ class DataServiceHarvester(
                 }
                 updatedCatalogs.add(catalogMeta)
 
-                val catalogFdkUri = "${applicationProperties.dataserviceUri.substringBeforeLast("/")}/catalogs/${catalogMeta.fdkId}"
+                val catalogFdkUri =
+                    "${applicationProperties.dataserviceUri.substringBeforeLast("/")}/catalogs/${catalogMeta.fdkId}"
                 it.first.services.forEach { service ->
-                    validateSourceUrl(service.resourceURI, harvestSource, resourceRepository.findByIdOrNull(service.resourceURI))
-                    val result = service.updateDBOs(harvestDate, forceUpdate, harvestSource)
-                    result?.let { serviceMeta ->
-                        updatedServices.add(FdkIdAndUri(fdkId = serviceMeta.fdkId, uri = serviceMeta.uri))
-                        val catalogRecordModel = createDataServiceCatalogRecordModel(
-                            dataserviceUri = serviceMeta.uri,
-                            dataserviceFdkId = serviceMeta.fdkId,
-                            catalogFdkUri = catalogFdkUri,
-                            issued = serviceMeta.issued,
-                            modified = serviceMeta.modified,
-                            dataserviceUriBase = applicationProperties.dataserviceUri
+                    try {
+                        validateSourceUrl(
+                            service.resourceURI,
+                            harvestSource,
+                            resourceRepository.findByIdOrNull(service.resourceURI)
                         )
-                        val graphWithRecords = service.harvestedService.union(catalogRecordModel)
-                        val graphString = graphWithRecords.createRDFResponse(Lang.TURTLE)
-                        resourceGraphs[serviceMeta.fdkId] = graphString
+                        val result = service.updateDBOs(harvestDate, forceUpdate, harvestSource)
+                        result?.let { serviceMeta ->
+                            updatedServices.add(FdkIdAndUri(fdkId = serviceMeta.fdkId, uri = serviceMeta.uri))
+                            val catalogRecordModel = createDataServiceCatalogRecordModel(
+                                dataserviceUri = serviceMeta.uri,
+                                dataserviceFdkId = serviceMeta.fdkId,
+                                catalogFdkUri = catalogFdkUri,
+                                issued = serviceMeta.issued,
+                                modified = serviceMeta.modified,
+                                dataserviceUriBase = applicationProperties.dataserviceUri
+                            )
+                            val graphWithRecords = service.harvestedService.union(catalogRecordModel)
+                            val graphString = graphWithRecords.createRDFResponse(Lang.TURTLE)
+                            resourceGraphs[serviceMeta.fdkId] = graphString
+                        }
+                    } catch (conflictError: HarvestSourceConflictException) {
+                        logger.warn("Data service skipped due to conflict when harvesting {}: {}", harvestSource.uri, conflictError.message)
                     }
                 }
             }
-        
+
         // Mark data services as removed if they were harvested from this source but are no longer present
         val servicesFromThisSource = resourceRepository.findAllByType(ResourceType.DATASERVICE)
             .filter { it.harvestSource.id == harvestSource.id && !it.removed }
@@ -111,10 +131,10 @@ class DataServiceHarvester(
         removedServices.addAll(
             servicesFromThisSource.filter { !currentServiceUris.contains(it.uri) }
         )
-        
+
         removedServices.map { it.copy(removed = true) }.run { resourceRepository.saveAll(this) }
-        LOGGER.debug("Harvest of $sourceUrl completed")
-        
+        logger.debug("Harvest of $sourceUrl completed")
+
         val report = HarvestReport(
             runId = runId,
             dataSourceId = sourceId,
@@ -161,11 +181,17 @@ class DataServiceHarvester(
                 resourceRepository.save(updatedMeta)
                 updatedMeta
             }
+
             forceUpdate -> {
-                val updatedMeta = dbMeta.copy(checksum = harvestedChecksum, modified = harvestDate.toInstant(), harvestSource = harvestSource)
+                val updatedMeta = dbMeta.copy(
+                    checksum = harvestedChecksum,
+                    modified = harvestDate.toInstant(),
+                    harvestSource = harvestSource
+                )
                 resourceRepository.save(updatedMeta)
                 updatedMeta
             }
+
             else -> null
         }
     }
@@ -213,7 +239,10 @@ class DataServiceHarvester(
         )
     }
 
-    private fun CatalogAndDataServiceModels.catalogHasChanges(dbMeta: ResourceEntity?, harvestedChecksum: String): Boolean =
+    private fun CatalogAndDataServiceModels.catalogHasChanges(
+        dbMeta: ResourceEntity?,
+        harvestedChecksum: String
+    ): Boolean =
         if (dbMeta == null) true
         else harvestedChecksum != dbMeta.checksum
 
@@ -274,7 +303,7 @@ class DataServiceHarvester(
         filter {
             if (it.isURIResource) true
             else {
-                LOGGER.warn("Blank node catalog or data service filtered when harvesting $sourceURL")
+                logger.warn("Blank node catalog or data service filtered when harvesting $sourceURL")
                 false
             }
         }
@@ -283,6 +312,7 @@ class DataServiceHarvester(
         when {
             property.predicate != DCAT.service && property.isResourceProperty() ->
                 add(property).recursiveAddNonDataServiceResource(property.resource)
+
             property.predicate != DCAT.service -> add(property)
             property.isResourceProperty() && property.resource.isURIResource -> add(property)
             else -> this

--- a/src/main/kotlin/no/fdk/fdk_harvester/harvester/DatasetHarvester.kt
+++ b/src/main/kotlin/no/fdk/fdk_harvester/harvester/DatasetHarvester.kt
@@ -2,15 +2,20 @@ package no.fdk.fdk_harvester.harvester
 
 import no.fdk.fdk_harvester.config.ApplicationProperties
 import no.fdk.fdk_harvester.kafka.ResourceEventProducer
-import no.fdk.fdk_harvester.model.*
+import no.fdk.fdk_harvester.model.FdkIdAndUri
+import no.fdk.fdk_harvester.model.HarvestDataSource
+import no.fdk.fdk_harvester.model.HarvestReport
+import no.fdk.fdk_harvester.model.HarvestSourceEntity
 import no.fdk.fdk_harvester.model.ResourceEntity
-import no.fdk.fdk_harvester.rdf.*
+import no.fdk.fdk_harvester.model.ResourceType
 import no.fdk.fdk_harvester.rdf.DCAT3
+import no.fdk.fdk_harvester.rdf.computeChecksum
+import no.fdk.fdk_harvester.rdf.containsTriple
 import no.fdk.fdk_harvester.rdf.createDatasetCatalogRecordModel
+import no.fdk.fdk_harvester.rdf.createIdFromString
+import no.fdk.fdk_harvester.rdf.createRDFResponse
 import no.fdk.fdk_harvester.repository.HarvestSourceRepository
 import no.fdk.fdk_harvester.repository.ResourceRepository
-import no.fdk.fdk_harvester.rdf.computeChecksum
-import no.fdk.harvest.DataType as HarvestDataType
 import org.apache.jena.rdf.model.Model
 import org.apache.jena.rdf.model.ModelFactory
 import org.apache.jena.rdf.model.Resource
@@ -18,10 +23,10 @@ import org.apache.jena.rdf.model.Statement
 import org.apache.jena.riot.Lang
 import org.apache.jena.vocabulary.DCAT
 import org.apache.jena.vocabulary.RDF
-import org.slf4j.LoggerFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import java.util.*
+import no.fdk.harvest.DataType as HarvestDataType
 
 /** Harvests DCAT dataset catalogs from RDF and publishes dataset events (with FDK catalog records in the graph). */
 @Service
@@ -32,7 +37,12 @@ class DatasetHarvester(
     private val resourceEventProducer: ResourceEventProducer
 ) : BaseHarvester(harvestSourceRepository) {
 
-    fun harvestDatasetCatalog(source: HarvestDataSource, harvestDate: Calendar, forceUpdate: Boolean, runId: String): HarvestReport? =
+    fun harvestDatasetCatalog(
+        source: HarvestDataSource,
+        harvestDate: Calendar,
+        forceUpdate: Boolean,
+        runId: String
+    ): HarvestReport? =
         validateAndHarvest(source, harvestDate, forceUpdate, runId, "dataset", requiresAcceptHeader = true)
 
     override fun updateDB(
@@ -52,25 +62,25 @@ class DatasetHarvester(
         val resourceGraphs = mutableMapOf<String, String>()
         val catalogPairs = extractCatalogs(harvested, sourceUrl)
             .map { Pair(it, resourceRepository.findByIdOrNull(it.resource.uri)) }
-        // Validate source ownership for all resources in the feed before filtering by change (avoids reporting 0 change when feed contains resources owned by another source)
+        // Validate source ownership for all catalogs in the feed before filtering by change
         catalogPairs.forEach { (catalog, dbCatalog) ->
             validateSourceUrl(catalog.resource.uri, harvestSource, dbCatalog)
-            catalog.datasets.forEach { dataset ->
-                validateSourceUrl(dataset.resource.uri, harvestSource, resourceRepository.findByIdOrNull(dataset.resource.uri))
-            }
         }
         catalogPairs
             .filter { forceUpdate || it.first.catalogHasChanges(it.second) }
             .forEach {
                 val dbMeta = it.second
-                validateSourceUrl(it.first.resource.uri, harvestSource, dbMeta)
                 val catalogChecksum = computeChecksum(it.first.harvestedCatalog)
                 val catalogMeta = if (dbMeta == null || it.first.catalogHasChanges(dbMeta)) {
                     it.first.mapToResource(harvestDate, dbMeta, catalogChecksum, harvestSource)
                         .also { updatedMeta -> resourceRepository.save(updatedMeta) }
                 } else {
                     if (forceUpdate) {
-                        dbMeta.copy(checksum = catalogChecksum, modified = harvestDate.toInstant(), harvestSource = harvestSource)
+                        dbMeta.copy(
+                            checksum = catalogChecksum,
+                            modified = harvestDate.toInstant(),
+                            harvestSource = harvestSource
+                        )
                             .also { resourceRepository.save(it) }
                     } else {
                         dbMeta
@@ -78,23 +88,32 @@ class DatasetHarvester(
                 }
                 updatedCatalogs.add(catalogMeta)
 
-                val catalogFdkUri = "${applicationProperties.datasetUri.substringBeforeLast("/")}/catalogs/${catalogMeta.fdkId}"
+                val catalogFdkUri =
+                    "${applicationProperties.datasetUri.substringBeforeLast("/")}/catalogs/${catalogMeta.fdkId}"
                 it.first.datasets.forEach { dataset ->
-                    validateSourceUrl(dataset.resource.uri, harvestSource, resourceRepository.findByIdOrNull(dataset.resource.uri))
-                    val result = dataset.updateDataset(harvestDate, forceUpdate, harvestSource)
-                    result?.let { datasetMeta ->
-                        updatedDatasets.add(datasetMeta)
-                        val catalogRecordModel = createDatasetCatalogRecordModel(
-                            datasetUri = datasetMeta.uri,
-                            datasetFdkId = datasetMeta.fdkId,
-                            catalogFdkUri = catalogFdkUri,
-                            issued = datasetMeta.issued,
-                            modified = datasetMeta.modified,
-                            datasetUriBase = applicationProperties.datasetUri
+                    try {
+                        validateSourceUrl(
+                            dataset.resource.uri,
+                            harvestSource,
+                            resourceRepository.findByIdOrNull(dataset.resource.uri)
                         )
-                        val graphWithRecords = dataset.harvestedDataset.union(catalogRecordModel)
-                        val graphString = graphWithRecords.createRDFResponse(Lang.TURTLE)
-                        resourceGraphs[datasetMeta.fdkId] = graphString
+                        val result = dataset.updateDataset(harvestDate, forceUpdate, harvestSource)
+                        result?.let { datasetMeta ->
+                            updatedDatasets.add(datasetMeta)
+                            val catalogRecordModel = createDatasetCatalogRecordModel(
+                                datasetUri = datasetMeta.uri,
+                                datasetFdkId = datasetMeta.fdkId,
+                                catalogFdkUri = catalogFdkUri,
+                                issued = datasetMeta.issued,
+                                modified = datasetMeta.modified,
+                                datasetUriBase = applicationProperties.datasetUri
+                            )
+                            val graphWithRecords = dataset.harvestedDataset.union(catalogRecordModel)
+                            val graphString = graphWithRecords.createRDFResponse(Lang.TURTLE)
+                            resourceGraphs[datasetMeta.fdkId] = graphString
+                        }
+                    } catch (conflictError: HarvestSourceConflictException) {
+                        logger.warn("Dataset skipped due to conflict when harvesting {}: {}", harvestSource.uri, conflictError.message)
                     }
                 }
             }
@@ -153,11 +172,17 @@ class DatasetHarvester(
                 resourceRepository.save(datasetMeta)
                 datasetMeta
             }
+
             forceUpdate -> {
-                val updatedMeta = dbMeta.copy(checksum = harvestedChecksum, modified = harvestDate.toInstant(), harvestSource = harvestSource)
+                val updatedMeta = dbMeta.copy(
+                    checksum = harvestedChecksum,
+                    modified = harvestDate.toInstant(),
+                    harvestSource = harvestSource
+                )
                 resourceRepository.save(updatedMeta)
                 updatedMeta
             }
+
             else -> null
         }
     }
@@ -274,6 +299,7 @@ class DatasetHarvester(
         when {
             property.predicate != DCAT.dataset && property.isResourceProperty() ->
                 add(property).recursiveAddNonDatasetResource(property.resource)
+
             property.predicate != DCAT.dataset -> add(property)
             property.isResourceProperty() && property.resource.isURIResource -> add(property)
             else -> this

--- a/src/main/kotlin/no/fdk/fdk_harvester/harvester/EventHarvester.kt
+++ b/src/main/kotlin/no/fdk/fdk_harvester/harvester/EventHarvester.kt
@@ -3,15 +3,22 @@ package no.fdk.fdk_harvester.harvester
 import no.fdk.fdk_harvester.adapter.DefaultOrganizationsAdapter
 import no.fdk.fdk_harvester.config.ApplicationProperties
 import no.fdk.fdk_harvester.kafka.ResourceEventProducer
-import no.fdk.fdk_harvester.model.*
-import no.fdk.fdk_harvester.rdf.*
+import no.fdk.fdk_harvester.model.FdkIdAndUri
+import no.fdk.fdk_harvester.model.HarvestDataSource
+import no.fdk.fdk_harvester.model.HarvestReport
+import no.fdk.fdk_harvester.model.HarvestSourceEntity
+import no.fdk.fdk_harvester.model.Organization
+import no.fdk.fdk_harvester.model.ResourceEntity
+import no.fdk.fdk_harvester.model.ResourceType
+import no.fdk.fdk_harvester.rdf.CV
+import no.fdk.fdk_harvester.rdf.DCATNO
+import no.fdk.fdk_harvester.rdf.computeChecksum
+import no.fdk.fdk_harvester.rdf.containsTriple
 import no.fdk.fdk_harvester.rdf.createEventCatalogRecordModel
+import no.fdk.fdk_harvester.rdf.createIdFromString
+import no.fdk.fdk_harvester.rdf.createRDFResponse
 import no.fdk.fdk_harvester.repository.HarvestSourceRepository
 import no.fdk.fdk_harvester.repository.ResourceRepository
-import no.fdk.fdk_harvester.rdf.computeChecksum
-import no.fdk.fdk_harvester.harvester.formatNowWithOsloTimeZone
-import no.fdk.fdk_harvester.harvester.formatWithOsloTimeZone
-import no.fdk.harvest.DataType as HarvestDataType
 import org.apache.jena.query.QueryExecutionFactory
 import org.apache.jena.query.QueryFactory
 import org.apache.jena.rdf.model.Model
@@ -24,12 +31,10 @@ import org.apache.jena.vocabulary.DCAT
 import org.apache.jena.vocabulary.DCTerms
 import org.apache.jena.vocabulary.RDF
 import org.apache.jena.vocabulary.RDFS
-import org.slf4j.LoggerFactory
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import java.util.*
-
-private val LOGGER = LoggerFactory.getLogger(EventHarvester::class.java)
+import no.fdk.harvest.DataType as HarvestDataType
 
 /** Harvests event catalogs from RDF and publishes event events (with FDK catalog records in the graph). */
 @Service
@@ -41,7 +46,12 @@ class EventHarvester(
     harvestSourceRepository: HarvestSourceRepository
 ) : BaseHarvester(harvestSourceRepository) {
 
-    fun harvestEvents(source: HarvestDataSource, harvestDate: Calendar, forceUpdate: Boolean, runId: String): HarvestReport? =
+    fun harvestEvents(
+        source: HarvestDataSource,
+        harvestDate: Calendar,
+        forceUpdate: Boolean,
+        runId: String
+    ): HarvestReport? =
         validateAndHarvest(source, harvestDate, forceUpdate, runId, "event", requiresAcceptHeader = true)
 
     override fun updateDB(
@@ -62,15 +72,26 @@ class EventHarvester(
         } else null
 
         val catalogs = splitCatalogsFromRDF(harvested, allEvents, sourceUrl, organization)
-        val (updatedCatalogs, eventUriToCatalogFdkUri) = updateCatalogs(catalogs, harvestDate, forceUpdate, harvestSource)
-        val (updatedEvents, resourceGraphs) = updateEvents(allEvents, harvestDate, forceUpdate, harvestSource, eventUriToCatalogFdkUri)
+        val (updatedCatalogs, eventUriToCatalogFdkUri) = updateCatalogs(
+            catalogs,
+            harvestDate,
+            forceUpdate,
+            harvestSource
+        )
+        val (updatedEvents, resourceGraphs) = updateEvents(
+            allEvents,
+            harvestDate,
+            forceUpdate,
+            harvestSource,
+            eventUriToCatalogFdkUri
+        )
 
         // Mark events as removed if they were harvested from this source but are no longer present
         val eventsFromThisSource = resourceRepository.findAllByType(ResourceType.EVENT)
             .filter { it.harvestSource.id == harvestSource.id && !it.removed }
         val currentEventUris = allEvents.map { it.eventURI }.toSet()
         val removedEvents = eventsFromThisSource.filter { !currentEventUris.contains(it.uri) }
-        
+
         removedEvents.map { it.copy(removed = true) }
             .run { resourceRepository.saveAll(this) }
 
@@ -107,35 +128,45 @@ class EventHarvester(
         return report
     }
 
-    private fun updateCatalogs(catalogs: List<CatalogAndEventModels>, harvestDate: Calendar, forceUpdate: Boolean, harvestSource: HarvestSourceEntity): Pair<List<FdkIdAndUri>, Map<String, String>> {
+    private fun updateCatalogs(
+        catalogs: List<CatalogAndEventModels>,
+        harvestDate: Calendar,
+        forceUpdate: Boolean,
+        harvestSource: HarvestSourceEntity
+    ): Pair<List<FdkIdAndUri>, Map<String, String>> {
         val eventUriToCatalogFdkUri = mutableMapOf<String, String>()
-        // Validate source ownership for all catalogs and events before filtering by change (avoids reporting 0 change when feed contains resources owned by another source)
+        // Validate source ownership for all catalogs before filtering by change
         catalogs.forEach { catalog ->
-            validateSourceUrl(catalog.resourceURI, harvestSource, resourceRepository.findByIdOrNull(catalog.resourceURI))
-            catalog.events.forEach { eventURI ->
-                validateSourceUrl(eventURI, harvestSource, resourceRepository.findByIdOrNull(eventURI))
-            }
+            validateSourceUrl(
+                catalog.resourceURI,
+                harvestSource,
+                resourceRepository.findByIdOrNull(catalog.resourceURI)
+            )
         }
         val updatedCatalogs = catalogs
             .map { Pair(it, resourceRepository.findByIdOrNull(it.resourceURI)) }
             .filter { forceUpdate || it.first.catalogHasChanges(it.second, computeChecksum(it.first.harvestedCatalog)) }
             .map {
                 val dbMeta = it.second
-                validateSourceUrl(it.first.resourceURI, harvestSource, dbMeta)
                 val catalogChecksum = computeChecksum(it.first.harvestedCatalog)
                 val catalogMeta = if (dbMeta == null || it.first.catalogHasChanges(dbMeta, catalogChecksum)) {
                     it.first.mapToResource(harvestDate, dbMeta, catalogChecksum, harvestSource)
                         .also { updatedMeta -> resourceRepository.save(updatedMeta) }
                 } else {
                     if (forceUpdate) {
-                        dbMeta.copy(checksum = catalogChecksum, modified = harvestDate.toInstant(), harvestSource = harvestSource)
+                        dbMeta.copy(
+                            checksum = catalogChecksum,
+                            modified = harvestDate.toInstant(),
+                            harvestSource = harvestSource
+                        )
                             .also { resourceRepository.save(it) }
                     } else {
                         dbMeta
                     }
                 }
 
-                val catalogFdkUri = "${applicationProperties.eventUri.substringBeforeLast("/")}/catalogs/${catalogMeta.fdkId}"
+                val catalogFdkUri =
+                    "${applicationProperties.eventUri.substringBeforeLast("/")}/catalogs/${catalogMeta.fdkId}"
                 it.first.events.forEach { eventURI ->
                     addIsPartOfToEvents(eventURI, catalogMeta.uri)
                     eventUriToCatalogFdkUri[eventURI] = catalogFdkUri
@@ -201,22 +232,37 @@ class EventHarvester(
         return Pair(updatedEvents, resourceGraphs)
     }
 
-    private fun EventRDFModel.updateDBOs(harvestDate: Calendar, forceUpdate: Boolean, harvestSource: HarvestSourceEntity): ResourceEntity? {
-        val dbMeta = resourceRepository.findByIdOrNull(eventURI)
-        validateSourceUrl(eventURI, harvestSource, dbMeta)
-        val harvestedChecksum = computeChecksum(harvested)
-        return when {
-            dbMeta == null || dbMeta.removed || hasChanges(dbMeta, harvestedChecksum) -> {
-                val updatedMeta = mapToResource(harvestDate, dbMeta, harvestedChecksum, harvestSource)
-                resourceRepository.save(updatedMeta)
-                updatedMeta
+    private fun EventRDFModel.updateDBOs(
+        harvestDate: Calendar,
+        forceUpdate: Boolean,
+        harvestSource: HarvestSourceEntity
+    ): ResourceEntity? {
+        try {
+            val dbMeta = resourceRepository.findByIdOrNull(eventURI)
+            validateSourceUrl(eventURI, harvestSource, dbMeta)
+            val harvestedChecksum = computeChecksum(harvested)
+            return when {
+                dbMeta == null || dbMeta.removed || hasChanges(dbMeta, harvestedChecksum) -> {
+                    val updatedMeta = mapToResource(harvestDate, dbMeta, harvestedChecksum, harvestSource)
+                    resourceRepository.save(updatedMeta)
+                    updatedMeta
+                }
+
+                forceUpdate -> {
+                    val updatedMeta = dbMeta.copy(
+                        checksum = harvestedChecksum,
+                        modified = harvestDate.toInstant(),
+                        harvestSource = harvestSource
+                    )
+                    resourceRepository.save(updatedMeta)
+                    updatedMeta
+                }
+
+                else -> null
             }
-            forceUpdate -> {
-                val updatedMeta = dbMeta.copy(checksum = harvestedChecksum, modified = harvestDate.toInstant(), harvestSource = harvestSource)
-                resourceRepository.save(updatedMeta)
-                updatedMeta
-            }
-            else -> null
+        } catch (conflictError: HarvestSourceConflictException) {
+            logger.warn("Event skipped due to conflict when harvesting {}: {}", harvestSource.uri, conflictError.message)
+            return null
         }
     }
 
@@ -241,7 +287,10 @@ class EventHarvester(
         )
     }
 
-    private fun getEventsRemovedThisHarvest(events: List<String>, harvestSource: HarvestSourceEntity): List<ResourceEntity> =
+    private fun getEventsRemovedThisHarvest(
+        events: List<String>,
+        harvestSource: HarvestSourceEntity
+    ): List<ResourceEntity> =
         resourceRepository.findAllByType(ResourceType.EVENT)
             .filter { it.harvestSource.id == harvestSource.id && !it.removed && !events.contains(it.uri) }
 
@@ -264,7 +313,12 @@ class EventHarvester(
             .filterBlankNodeEvents(sourceURL)
             .map { eventResource -> eventResource.extractEvent() }
 
-    private fun splitCatalogsFromRDF(harvested: Model, allEvents: List<EventRDFModel>, sourceURL: String, organization: Organization?): List<CatalogAndEventModels> {
+    private fun splitCatalogsFromRDF(
+        harvested: Model,
+        allEvents: List<EventRDFModel>,
+        sourceURL: String,
+        organization: Organization?
+    ): List<CatalogAndEventModels> {
         val harvestedCatalogs = harvested.listResourcesWithProperty(RDF.type, DCAT.Catalog)
             .toList()
             .filterBlankNodeCatalogsAndEvents(sourceURL)
@@ -292,10 +346,12 @@ class EventHarvester(
                 )
             }
 
-        return harvestedCatalogs.plus(generatedCatalog(
-            allEvents.filterNot { it.isMemberOfAnyCatalog },
-            sourceURL,
-            organization)
+        return harvestedCatalogs.plus(
+            generatedCatalog(
+                allEvents.filterNot { it.isMemberOfAnyCatalog },
+                sourceURL,
+                organization
+            )
         )
     }
 
@@ -310,7 +366,7 @@ class EventHarvester(
         filter {
             if (it.isURIResource) true
             else {
-                LOGGER.warn("Blank node event filtered when harvesting $sourceURL")
+                logger.warn("Blank node event filtered when harvesting $sourceURL")
                 false
             }
         }
@@ -319,7 +375,7 @@ class EventHarvester(
         filter {
             if (it.isURIResource) true
             else {
-                LOGGER.warn("Blank node catalog or event filtered when harvesting $sourceURL")
+                logger.warn("Blank node catalog or event filtered when harvesting $sourceURL")
                 false
             }
         }
@@ -352,6 +408,7 @@ class EventHarvester(
         when {
             property.predicate != DCATNO.containsEvent && property.isResourceProperty() ->
                 add(property).recursiveAddNonEventResource(property.resource)
+
             property.predicate != DCATNO.containsEvent -> add(property)
             property.isResourceProperty() && property.resource.isURIResource -> add(property)
             else -> this

--- a/src/main/kotlin/no/fdk/fdk_harvester/harvester/InformationModelHarvester.kt
+++ b/src/main/kotlin/no/fdk/fdk_harvester/harvester/InformationModelHarvester.kt
@@ -2,14 +2,20 @@ package no.fdk.fdk_harvester.harvester
 
 import no.fdk.fdk_harvester.config.ApplicationProperties
 import no.fdk.fdk_harvester.kafka.ResourceEventProducer
-import no.fdk.fdk_harvester.model.*
+import no.fdk.fdk_harvester.model.FdkIdAndUri
+import no.fdk.fdk_harvester.model.HarvestDataSource
+import no.fdk.fdk_harvester.model.HarvestReport
+import no.fdk.fdk_harvester.model.HarvestSourceEntity
 import no.fdk.fdk_harvester.model.ResourceEntity
-import no.fdk.fdk_harvester.rdf.*
+import no.fdk.fdk_harvester.model.ResourceType
+import no.fdk.fdk_harvester.rdf.ModellDCATAPNO
+import no.fdk.fdk_harvester.rdf.computeChecksum
+import no.fdk.fdk_harvester.rdf.containsTriple
+import no.fdk.fdk_harvester.rdf.createIdFromString
 import no.fdk.fdk_harvester.rdf.createInformationModelCatalogRecordModel
+import no.fdk.fdk_harvester.rdf.createRDFResponse
 import no.fdk.fdk_harvester.repository.HarvestSourceRepository
 import no.fdk.fdk_harvester.repository.ResourceRepository
-import no.fdk.fdk_harvester.rdf.computeChecksum
-import no.fdk.harvest.DataType as HarvestDataType
 import org.apache.jena.rdf.model.Model
 import org.apache.jena.rdf.model.ModelFactory
 import org.apache.jena.rdf.model.Resource
@@ -21,6 +27,7 @@ import org.apache.jena.vocabulary.SKOS
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import java.util.*
+import no.fdk.harvest.DataType as HarvestDataType
 
 /** Harvests information model catalogs from RDF and publishes informationmodel events (with FDK catalog records in the graph). */
 @Service
@@ -31,7 +38,12 @@ class InformationModelHarvester(
     private val resourceEventProducer: ResourceEventProducer
 ) : BaseHarvester(harvestSourceRepository) {
 
-    fun harvestInformationModelCatalog(source: HarvestDataSource, harvestDate: Calendar, forceUpdate: Boolean, runId: String): HarvestReport? =
+    fun harvestInformationModelCatalog(
+        source: HarvestDataSource,
+        harvestDate: Calendar,
+        forceUpdate: Boolean,
+        runId: String
+    ): HarvestReport? =
         validateAndHarvest(source, harvestDate, forceUpdate, runId, "informationmodel", requiresAcceptHeader = true)
 
     override fun updateDB(
@@ -51,25 +63,29 @@ class InformationModelHarvester(
         val resourceGraphs = mutableMapOf<String, String>()
         val catalogPairs = splitCatalogsFromRDF(harvested, sourceUrl)
             .map { Pair(it, resourceRepository.findByIdOrNull(it.resourceURI)) }
-        // Validate source ownership for all catalogs and models before filtering by change (avoids reporting 0 change when feed contains resources owned by another source)
+        // Validate source ownership for all catalogs before filtering by change
         catalogPairs.forEach { (catalog, _) ->
-            validateSourceUrl(catalog.resourceURI, harvestSource, resourceRepository.findByIdOrNull(catalog.resourceURI))
-            catalog.models.forEach { infoModel ->
-                validateSourceUrl(infoModel.resourceURI, harvestSource, resourceRepository.findByIdOrNull(infoModel.resourceURI))
-            }
+            validateSourceUrl(
+                catalog.resourceURI,
+                harvestSource,
+                resourceRepository.findByIdOrNull(catalog.resourceURI)
+            )
         }
         catalogPairs
             .filter { forceUpdate || it.first.catalogHasChanges(it.second) }
             .forEach {
                 val dbMeta = it.second
-                validateSourceUrl(it.first.resourceURI, harvestSource, dbMeta)
                 val catalogChecksum = computeChecksum(it.first.harvestedCatalog)
                 val updatedCatalogMeta = if (dbMeta == null || it.first.catalogHasChanges(dbMeta)) {
                     it.first.mapToResource(harvestDate, dbMeta, catalogChecksum, harvestSource)
                         .also { resourceRepository.save(it) }
                 } else {
                     if (forceUpdate) {
-                        dbMeta.copy(checksum = catalogChecksum, modified = harvestDate.toInstant(), harvestSource = harvestSource)
+                        dbMeta.copy(
+                            checksum = catalogChecksum,
+                            modified = harvestDate.toInstant(),
+                            harvestSource = harvestSource
+                        )
                             .also { resourceRepository.save(it) }
                     } else {
                         dbMeta
@@ -77,27 +93,36 @@ class InformationModelHarvester(
                 }
                 updatedCatalogs.add(updatedCatalogMeta)
 
-                val catalogFdkUri = "${applicationProperties.informationmodelUri.substringBeforeLast("/")}/catalogs/${updatedCatalogMeta.fdkId}"
+                val catalogFdkUri =
+                    "${applicationProperties.informationmodelUri.substringBeforeLast("/")}/catalogs/${updatedCatalogMeta.fdkId}"
                 it.first.models.forEach { infoModel ->
-                    validateSourceUrl(infoModel.resourceURI, harvestSource, resourceRepository.findByIdOrNull(infoModel.resourceURI))
-                    val result = infoModel.updateDBOs(harvestDate, forceUpdate, harvestSource)
-                    result?.let { modelMeta ->
-                        updatedModels.add(modelMeta)
-                        val catalogRecordModel = createInformationModelCatalogRecordModel(
-                            informationModelUri = modelMeta.uri,
-                            informationModelFdkId = modelMeta.fdkId,
-                            catalogFdkUri = catalogFdkUri,
-                            issued = modelMeta.issued,
-                            modified = modelMeta.modified,
-                            informationModelUriBase = applicationProperties.informationmodelUri
+                    try {
+                        validateSourceUrl(
+                            infoModel.resourceURI,
+                            harvestSource,
+                            resourceRepository.findByIdOrNull(infoModel.resourceURI)
                         )
-                        val graphWithRecords = infoModel.harvested.union(catalogRecordModel)
-                        val graphString = graphWithRecords.createRDFResponse(Lang.TURTLE)
-                        resourceGraphs[modelMeta.fdkId] = graphString
+                        val result = infoModel.updateDBOs(harvestDate, forceUpdate, harvestSource)
+                        result?.let { modelMeta ->
+                            updatedModels.add(modelMeta)
+                            val catalogRecordModel = createInformationModelCatalogRecordModel(
+                                informationModelUri = modelMeta.uri,
+                                informationModelFdkId = modelMeta.fdkId,
+                                catalogFdkUri = catalogFdkUri,
+                                issued = modelMeta.issued,
+                                modified = modelMeta.modified,
+                                informationModelUriBase = applicationProperties.informationmodelUri
+                            )
+                            val graphWithRecords = infoModel.harvested.union(catalogRecordModel)
+                            val graphString = graphWithRecords.createRDFResponse(Lang.TURTLE)
+                            resourceGraphs[modelMeta.fdkId] = graphString
+                        }
+                    } catch (conflictError: HarvestSourceConflictException) {
+                        logger.warn("Information modeel skipped due to conflict when harvesting {}: {}", harvestSource.uri, conflictError.message)
                     }
                 }
             }
-        
+
         // Mark models as removed if they were harvested from this source but are no longer present
         val modelsFromThisSource = resourceRepository.findAllByType(ResourceType.INFORMATIONMODEL)
             .filter { it.harvestSource.id == harvestSource.id && !it.removed }
@@ -152,11 +177,17 @@ class InformationModelHarvester(
                 resourceRepository.save(updatedMeta)
                 updatedMeta
             }
+
             forceUpdate -> {
-                val updatedMeta = dbMeta.copy(checksum = harvestedChecksum, modified = harvestDate.toInstant(), harvestSource = harvestSource)
+                val updatedMeta = dbMeta.copy(
+                    checksum = harvestedChecksum,
+                    modified = harvestDate.toInstant(),
+                    harvestSource = harvestSource
+                )
                 resourceRepository.save(updatedMeta)
                 updatedMeta
             }
+
             else -> null
         }
     }
@@ -223,12 +254,13 @@ class InformationModelHarvester(
             .toList()
             .filterBlankNodeCatalogsAndModels(sourceURL)
             .map { catalogResource ->
-                val catalogInfoModels: List<InformationModelRDFModel> = catalogResource.listProperties(ModellDCATAPNO.model)
-                    .toList()
-                    .map { it.resource }
-                    .filterBlankNodeCatalogsAndModels(sourceURL)
-                    .filter { catalogContainsInfoModel(harvested, catalogResource.uri, it.uri) }
-                    .map { infoModel -> infoModel.extractInformationModel() }
+                val catalogInfoModels: List<InformationModelRDFModel> =
+                    catalogResource.listProperties(ModellDCATAPNO.model)
+                        .toList()
+                        .map { it.resource }
+                        .filterBlankNodeCatalogsAndModels(sourceURL)
+                        .filter { catalogContainsInfoModel(harvested, catalogResource.uri, it.uri) }
+                        .map { infoModel -> infoModel.extractInformationModel() }
 
                 val catalogModelWithoutInfoModels = catalogResource.extractCatalogModel()
                     .recursiveBlankNodeSkolem(catalogResource.uri)
@@ -269,6 +301,7 @@ class InformationModelHarvester(
         when {
             property.predicate != ModellDCATAPNO.model && property.isResourceProperty() ->
                 add(property).recursiveAddNonInformationModelResource(property.resource)
+
             property.predicate != ModellDCATAPNO.model -> add(property)
             property.isResourceProperty() && property.resource.isURIResource -> add(property)
             else -> this

--- a/src/main/kotlin/no/fdk/fdk_harvester/harvester/ServiceHarvester.kt
+++ b/src/main/kotlin/no/fdk/fdk_harvester/harvester/ServiceHarvester.kt
@@ -3,14 +3,24 @@ package no.fdk.fdk_harvester.harvester
 import no.fdk.fdk_harvester.adapter.DefaultOrganizationsAdapter
 import no.fdk.fdk_harvester.config.ApplicationProperties
 import no.fdk.fdk_harvester.kafka.ResourceEventProducer
-import no.fdk.fdk_harvester.model.*
-import no.fdk.fdk_harvester.rdf.*
+import no.fdk.fdk_harvester.model.FdkIdAndUri
+import no.fdk.fdk_harvester.model.HarvestDataSource
+import no.fdk.fdk_harvester.model.HarvestReport
+import no.fdk.fdk_harvester.model.HarvestSourceEntity
+import no.fdk.fdk_harvester.model.Organization
+import no.fdk.fdk_harvester.model.ResourceEntity
+import no.fdk.fdk_harvester.model.ResourceType
+import no.fdk.fdk_harvester.rdf.CPSV
+import no.fdk.fdk_harvester.rdf.CPSVNO
+import no.fdk.fdk_harvester.rdf.CV
+import no.fdk.fdk_harvester.rdf.DCATNO
+import no.fdk.fdk_harvester.rdf.computeChecksum
+import no.fdk.fdk_harvester.rdf.containsTriple
+import no.fdk.fdk_harvester.rdf.createIdFromString
+import no.fdk.fdk_harvester.rdf.createRDFResponse
 import no.fdk.fdk_harvester.rdf.createServiceCatalogRecordModel
 import no.fdk.fdk_harvester.repository.HarvestSourceRepository
 import no.fdk.fdk_harvester.repository.ResourceRepository
-import no.fdk.fdk_harvester.rdf.computeChecksum
-import no.fdk.fdk_harvester.model.Organization
-import no.fdk.harvest.DataType as HarvestDataType
 import org.apache.jena.query.QueryExecutionFactory
 import org.apache.jena.query.QueryFactory
 import org.apache.jena.rdf.model.Model
@@ -20,10 +30,14 @@ import org.apache.jena.rdf.model.Resource
 import org.apache.jena.rdf.model.ResourceFactory
 import org.apache.jena.rdf.model.Statement
 import org.apache.jena.riot.Lang
-import org.apache.jena.vocabulary.*
+import org.apache.jena.vocabulary.DCAT
+import org.apache.jena.vocabulary.DCTerms
+import org.apache.jena.vocabulary.RDF
+import org.apache.jena.vocabulary.RDFS
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import java.util.*
+import no.fdk.harvest.DataType as HarvestDataType
 
 /** Harvests CPSV/DCAT service catalogs from RDF and publishes service events (with FDK catalog records in the graph). */
 @Service
@@ -35,7 +49,12 @@ class ServiceHarvester(
     private val resourceEventProducer: ResourceEventProducer
 ) : BaseHarvester(harvestSourceRepository) {
 
-    fun harvestServices(source: HarvestDataSource, harvestDate: Calendar, forceUpdate: Boolean, runId: String): HarvestReport? =
+    fun harvestServices(
+        source: HarvestDataSource,
+        harvestDate: Calendar,
+        forceUpdate: Boolean,
+        runId: String
+    ): HarvestReport? =
         validateAndHarvest(source, harvestDate, forceUpdate, runId, "service", requiresAcceptHeader = true)
 
     override fun updateDB(
@@ -56,8 +75,19 @@ class ServiceHarvester(
         } else null
 
         val catalogs = splitCatalogsFromRDF(harvested, allServices, sourceUrl, organization)
-        val (updatedCatalogs, serviceUriToCatalogFdkUri) = updateCatalogs(catalogs, harvestDate, forceUpdate, harvestSource)
-        val (updatedServices, resourceGraphs) = updateServices(allServices, harvestDate, forceUpdate, harvestSource, serviceUriToCatalogFdkUri)
+        val (updatedCatalogs, serviceUriToCatalogFdkUri) = updateCatalogs(
+            catalogs,
+            harvestDate,
+            forceUpdate,
+            harvestSource
+        )
+        val (updatedServices, resourceGraphs) = updateServices(
+            allServices,
+            harvestDate,
+            forceUpdate,
+            harvestSource,
+            serviceUriToCatalogFdkUri
+        )
 
         val removedServices = getServicesRemovedThisHarvest(
             allServices.map { it.resourceURI },
@@ -97,37 +127,46 @@ class ServiceHarvester(
         return report
     }
 
-    private fun updateCatalogs(catalogs: List<ServiceCatalogRDFModel>, harvestDate: Calendar, forceUpdate: Boolean, harvestSource: HarvestSourceEntity): Pair<List<FdkIdAndUri>, Map<String, String>> {
+    private fun updateCatalogs(
+        catalogs: List<ServiceCatalogRDFModel>,
+        harvestDate: Calendar,
+        forceUpdate: Boolean,
+        harvestSource: HarvestSourceEntity
+    ): Pair<List<FdkIdAndUri>, Map<String, String>> {
         val serviceUriToCatalogFdkUri = mutableMapOf<String, String>()
-        // Validate source ownership for all catalogs and services before filtering by change (avoids reporting 0 change when feed contains resources owned by another source)
+        // Validate source ownership for all catalogs before filtering by change
         catalogs.forEach { catalog ->
-            validateSourceUrl(catalog.resourceURI, harvestSource, resourceRepository.findByIdOrNull(catalog.resourceURI))
-            catalog.services.forEach { serviceURI ->
-                validateSourceUrl(serviceURI, harvestSource, resourceRepository.findByIdOrNull(serviceURI))
-            }
+            validateSourceUrl(
+                catalog.resourceURI,
+                harvestSource,
+                resourceRepository.findByIdOrNull(catalog.resourceURI)
+            )
         }
         val updatedCatalogs = catalogs
             .map { Pair(it, resourceRepository.findByIdOrNull(it.resourceURI)) }
             .filter { forceUpdate || it.first.hasChanges(it.second, computeChecksum(it.first.harvested)) }
             .map {
                 val dbMeta = it.second
-                validateSourceUrl(it.first.resourceURI, harvestSource, dbMeta)
                 val catalogChecksum = computeChecksum(it.first.harvested)
                 val updatedMeta = if (dbMeta == null || it.first.hasChanges(dbMeta, catalogChecksum)) {
                     it.first.mapToResourceMeta(harvestDate, dbMeta, catalogChecksum, harvestSource)
                         .also { resourceRepository.save(it) }
                 } else {
                     if (forceUpdate) {
-                        dbMeta.copy(checksum = catalogChecksum, modified = harvestDate.toInstant(), harvestSource = harvestSource)
+                        dbMeta.copy(
+                            checksum = catalogChecksum,
+                            modified = harvestDate.toInstant(),
+                            harvestSource = harvestSource
+                        )
                             .also { resourceRepository.save(it) }
                     } else {
                         dbMeta
                     }
                 }
 
-                val catalogFdkUri = "${applicationProperties.serviceUri.substringBeforeLast("/")}/catalogs/${updatedMeta.fdkId}"
+                val catalogFdkUri =
+                    "${applicationProperties.serviceUri.substringBeforeLast("/")}/catalogs/${updatedMeta.fdkId}"
                 it.first.services.forEach { serviceURI: String ->
-                    validateSourceUrl(serviceURI, harvestSource, resourceRepository.findByIdOrNull(serviceURI))
                     addIsPartOfToService(serviceURI, updatedMeta.uri)
                     serviceUriToCatalogFdkUri[serviceURI] = catalogFdkUri
                 }
@@ -192,22 +231,37 @@ class ServiceHarvester(
         return Pair(updatedServices, resourceGraphs)
     }
 
-    private fun ServiceRDFModel.updateDBOs(harvestDate: Calendar, forceUpdate: Boolean, harvestSource: HarvestSourceEntity): ResourceEntity? {
-        val dbMeta = resourceRepository.findByIdOrNull(resourceURI)
-        validateSourceUrl(resourceURI, harvestSource, dbMeta)
-        val harvestedChecksum = computeChecksum(harvested)
-        return when {
-            dbMeta == null || dbMeta.removed || hasChanges(dbMeta, harvestedChecksum) -> {
-                val updatedMeta = mapToResourceMeta(harvestDate, dbMeta, harvestedChecksum, harvestSource)
-                resourceRepository.save(updatedMeta)
-                updatedMeta
+    private fun ServiceRDFModel.updateDBOs(
+        harvestDate: Calendar,
+        forceUpdate: Boolean,
+        harvestSource: HarvestSourceEntity
+    ): ResourceEntity? {
+        try {
+            val dbMeta = resourceRepository.findByIdOrNull(resourceURI)
+            validateSourceUrl(resourceURI, harvestSource, dbMeta)
+            val harvestedChecksum = computeChecksum(harvested)
+            return when {
+                dbMeta == null || dbMeta.removed || hasChanges(dbMeta, harvestedChecksum) -> {
+                    val updatedMeta = mapToResourceMeta(harvestDate, dbMeta, harvestedChecksum, harvestSource)
+                    resourceRepository.save(updatedMeta)
+                    updatedMeta
+                }
+
+                forceUpdate -> {
+                    val updatedMeta = dbMeta.copy(
+                        checksum = harvestedChecksum,
+                        modified = harvestDate.toInstant(),
+                        harvestSource = harvestSource
+                    )
+                    resourceRepository.save(updatedMeta)
+                    updatedMeta
+                }
+
+                else -> null
             }
-            forceUpdate -> {
-                val updatedMeta = dbMeta.copy(checksum = harvestedChecksum, modified = harvestDate.toInstant(), harvestSource = harvestSource)
-                resourceRepository.save(updatedMeta)
-                updatedMeta
-            }
-            else -> null
+        } catch (conflictError: HarvestSourceConflictException) {
+            logger.warn("Service skipped due to conflict when harvesting {}: {}", harvestSource.uri, conflictError.message)
+            return null
         }
     }
 
@@ -232,7 +286,10 @@ class ServiceHarvester(
         )
     }
 
-    private fun getServicesRemovedThisHarvest(services: List<String>, harvestSource: HarvestSourceEntity): List<ResourceEntity> =
+    private fun getServicesRemovedThisHarvest(
+        services: List<String>,
+        harvestSource: HarvestSourceEntity
+    ): List<ResourceEntity> =
         resourceRepository.findAllByType(ResourceType.SERVICE)
             .filter { it.harvestSource.id == harvestSource.id && !it.removed && !services.contains(it.uri) }
 
@@ -249,8 +306,10 @@ class ServiceHarvester(
         if (dbMeta == null) true
         else harvestedChecksum != dbMeta.checksum
 
-    private fun splitCatalogsFromRDF(harvested: Model, allServices: List<ServiceRDFModel>,
-                                     sourceURL: String, organization: Organization?): List<ServiceCatalogRDFModel> {
+    private fun splitCatalogsFromRDF(
+        harvested: Model, allServices: List<ServiceRDFModel>,
+        sourceURL: String, organization: Organization?
+    ): List<ServiceCatalogRDFModel> {
         val harvestedCatalogs = harvested.listResourcesWithProperty(RDF.type, DCAT.Catalog)
             .toList()
             .excludeBlankNodes(sourceURL)
@@ -278,10 +337,12 @@ class ServiceHarvester(
                 )
             }
 
-        return harvestedCatalogs.plus(generatedCatalog(
-            allServices.filterNot { it.isMemberOfAnyCatalog },
-            sourceURL,
-            organization)
+        return harvestedCatalogs.plus(
+            generatedCatalog(
+                allServices.filterNot { it.isMemberOfAnyCatalog },
+                sourceURL,
+                organization
+            )
         )
     }
 
@@ -321,6 +382,7 @@ class ServiceHarvester(
         when {
             property.predicate != DCATNO.containsService && property.isResourceProperty() ->
                 add(property).recursiveAddNonServiceResources(property.resource)
+
             property.predicate != DCATNO.containsService -> add(property)
             property.isResourceProperty() && property.resource.isURIResource -> add(property)
             else -> this
@@ -368,7 +430,8 @@ class ServiceHarvester(
     ): ServiceCatalogRDFModel {
         val serviceURIs = services.map { it.resourceURI }.toSet()
         val generatedCatalogURI = "$sourceURL#GeneratedCatalog"
-        val catalogModelWithoutServices = createModelForHarvestSourceCatalog(generatedCatalogURI, serviceURIs, organization)
+        val catalogModelWithoutServices =
+            createModelForHarvestSourceCatalog(generatedCatalogURI, serviceURIs, organization)
 
         val catalogModel = ModelFactory.createDefaultModel()
         services.forEach { catalogModel.add(it.harvested) }

--- a/src/test/kotlin/no/fdk/fdk_harvester/harvester/HarvesterHappyPathTest.kt
+++ b/src/test/kotlin/no/fdk/fdk_harvester/harvester/HarvesterHappyPathTest.kt
@@ -20,6 +20,7 @@ import no.fdk.fdk_harvester.repository.HarvestSourceRepository
 import no.fdk.fdk_harvester.repository.ResourceRepository
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
@@ -87,6 +88,52 @@ class HarvesterHappyPathTest {
                 graphWithRecord.contains("isPartOf") || graphWithRecord.contains("dct:isPartOf"),
                 "produced graph should contain dct:isPartOf for record"
             )
+        } finally {
+            server.stop()
+        }
+    }
+
+    @Test
+    fun `dataset harvester - skips conflicting dataset and continues with remaining resources`() {
+        val conflictDatasetUri = "http://example.org/dataset-conflict"
+        val validDatasetUri = "http://example.org/dataset-ok"
+        val ttl = """
+            @prefix dcat: <http://www.w3.org/ns/dcat#> .
+            @prefix dct: <http://purl.org/dc/terms/> .
+            <http://example.org/catalog> a dcat:Catalog ;
+              dcat:dataset <$conflictDatasetUri> ;
+              dcat:dataset <$validDatasetUri> .
+            <$conflictDatasetUri> a dcat:Dataset ; dct:title "Conflicting dataset" .
+            <$validDatasetUri> a dcat:Dataset ; dct:title "Valid dataset" .
+        """.trimIndent()
+
+        val server = wireMock(ttl)
+        try {
+            val resourceRepository = mockResourceRepositoryWithConflicts(
+                mapOf(conflictDatasetUri to ResourceType.DATASET)
+            )
+            val harvestSourceRepository = mockHarvestSourceRepository()
+            val producer = mockk<ResourceEventProducer>(relaxed = true)
+
+            val appProps = ApplicationProperties(
+                datasetUri = "https://datasets.fellesdatakatalog.digdir.no/datasets"
+            )
+            val harvester = DatasetHarvester(appProps, resourceRepository, harvestSourceRepository, producer)
+            val report = harvester.harvestDatasetCatalog(
+                source = HarvestDataSource(
+                    id = "source-1",
+                    url = "http://localhost:${server.port()}/rdf",
+                    acceptHeaderValue = "text/turtle"
+                ),
+                harvestDate = Calendar.getInstance(),
+                forceUpdate = false,
+                runId = "run-1"
+            )
+
+            assertNotNull(report)
+            assertFalse(report!!.harvestError)
+            assertEquals(1, report.changedResources.size, "only non-conflicting dataset should be harvested")
+            assertEquals(validDatasetUri, report.changedResources.first().uri)
         } finally {
             server.stop()
         }
@@ -256,6 +303,53 @@ class HarvesterHappyPathTest {
     }
 
     @Test
+    fun `concept harvester - skips conflicting concept and continues with remaining concepts`() {
+        val conflictConceptUri = "http://example.org/concept-conflict"
+        val validConceptUri = "http://example.org/concept-ok"
+        val ttl = """
+            @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+            <http://example.org/collection> a skos:Collection ;
+              skos:member <$conflictConceptUri> ;
+              skos:member <$validConceptUri> .
+            <$conflictConceptUri> a skos:Concept .
+            <$validConceptUri> a skos:Concept .
+        """.trimIndent()
+
+        val server = wireMock(ttl)
+        try {
+            val orgAdapter = mockk<DefaultOrganizationsAdapter>(relaxed = true)
+            val resourceRepository = mockResourceRepositoryWithConflicts(
+                mapOf(conflictConceptUri to ResourceType.CONCEPT)
+            )
+            val harvestSourceRepository = mockHarvestSourceRepository()
+            val producer = mockk<ResourceEventProducer>(relaxed = true)
+
+            val appProps = ApplicationProperties(
+                conceptUri = "https://concepts.fellesdatakatalog.digdir.no/concepts"
+            )
+            val harvester = ConceptHarvester(orgAdapter, resourceRepository, producer, appProps, harvestSourceRepository)
+            val report = harvester.harvestConceptCollection(
+                source = HarvestDataSource(
+                    id = "source-1",
+                    url = "http://localhost:${server.port()}/rdf",
+                    acceptHeaderValue = "text/turtle",
+                    publisherId = null
+                ),
+                harvestDate = Calendar.getInstance(),
+                forceUpdate = false,
+                runId = "run-1"
+            )
+
+            assertNotNull(report)
+            assertFalse(report!!.harvestError)
+            assertEquals(1, report.changedResources.size, "only non-conflicting concept should be harvested")
+            assertEquals(validConceptUri, report.changedResources.first().uri)
+        } finally {
+            server.stop()
+        }
+    }
+
+    @Test
     fun `service harvester - harvestServices happy path`() {
         val ttl = """
             @prefix dcat: <http://www.w3.org/ns/dcat#> .
@@ -414,6 +508,42 @@ class HarvesterHappyPathTest {
     private fun mockResourceRepository(): ResourceRepository {
         val repo = mockk<ResourceRepository>()
         every { repo.findById(any<String>()) } returns Optional.empty()
+        every { repo.findAllByType(any()) } returns emptyList()
+        every { repo.findAllByTypeAndRemoved(any(), any()) } returns emptyList()
+        every { repo.findByFdkId(any()) } returns null
+        every { repo.findAllByFdkId(any()) } returns emptyList()
+        every { repo.save(any<ResourceEntity>()) } answers { firstArg() }
+        every { repo.saveAll(any<Iterable<ResourceEntity>>()) } answers { firstArg<Iterable<ResourceEntity>>().toList() }
+        return repo
+    }
+
+    private fun mockResourceRepositoryWithConflicts(conflicts: Map<String, ResourceType>): ResourceRepository {
+        val repo = mockk<ResourceRepository>()
+        every { repo.findById(any<String>()) } answers {
+            val uri = firstArg<String>()
+            val conflictType = conflicts[uri]
+            if (conflictType == null) {
+                Optional.empty()
+            } else {
+                Optional.of(
+                    ResourceEntity(
+                        uri = uri,
+                        type = conflictType,
+                        fdkId = "existing-fdk-id",
+                        removed = false,
+                        issued = Instant.now(),
+                        modified = Instant.now(),
+                        checksum = "existing-checksum",
+                        harvestSource = HarvestSourceEntity(
+                            id = 2L,
+                            uri = "http://example.org/other-source",
+                            checksum = "other-source-checksum",
+                            issued = Instant.now()
+                        )
+                    )
+                )
+            }
+        }
         every { repo.findAllByType(any()) } returns emptyList()
         every { repo.findAllByTypeAndRemoved(any(), any()) } returns emptyList()
         every { repo.findByFdkId(any()) } returns null


### PR DESCRIPTION
Per nå så avbrytes hele høstinga om en kilde inneholder en ressurs som allerede er høstet fra en annen kilde. Er tydeligvis litt for strengt, hopper i stedet bare over de med konflikt og gjennomfører høstinga som normalt for restende ressurser