### PR TITLE
chore: bump spring boot 4.1.0, add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,11 +4,22 @@ root = true
 charset = utf-8
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 
-[*.{kt,kts}]
-max_line_length = 140
+[*.md]
+trim_trailing_whitespace = false
 
 [*.{xml,yaml,yml,json}]
 indent_size = 2
+
+[*.{kt,kts}]
+ktlint_code_style = intellij_idea
+
+max_line_length = 140
+
+# No star imports
+ij_kotlin_packages_to_use_import_on_demand = unset
+ij_kotlin_name_count_to_use_star_import = 999
+ij_kotlin_name_count_to_use_star_import_for_members = 999

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.{kt,kts}]
+max_line_length = 140
+
+[*.{xml,yaml,yml,json}]
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ Event schemas are defined in `kafka/schemas/` (Avro). Code is documented with KD
 ## Initial deployment (empty database)
 
 On first deploy, the database has no harvest sources. Each harvest source is tracked in the database with an `initialized` flag. The first time a harvest runs for a given datasource URL, it is executed as a **forced** full harvest (so all resources are written), and the source is then marked initialized. Later harvests for that URL use normal change detection. No manual configuration is required: use the same scheduled harvest as usual; the first run per source is forced automatically, and subsequent runs are not.
+### Formatting code
+
+This project uses [ktlint](https://github.com/gantsign/ktlint-maven-plugin) to enforce a consistent code style.
+To automatically fix formatting violations, run:
+
+```sh
+mvn ktlint:format
+```

--- a/pom.xml
+++ b/pom.xml
@@ -373,9 +373,8 @@
                 <version>${ktlint.version}</version>
                 <executions>
                     <execution>
-                        <id>format-and-check</id>
+                        <id>ktlint-check</id>
                         <goals>
-                            <goal>format</goal>
                             <goal>check</goal>
                         </goals>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <parent>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-parent</artifactId>
-      <version>4.0.6</version>
+      <version>4.1.0</version>
       <relativePath/>
     </parent>
 
@@ -29,7 +29,11 @@
         <maven.exec.skip>false</maven.exec.skip>
         <!--end standard properties-->
 
+        <!-- Overrides Spring Boot 4.1.0 (42.7.11), which is still affected by CVE-2026-54291 -->
+        <postgresql.version>42.7.13</postgresql.version>
+
         <kotlin.version>2.3.21</kotlin.version>
+        <ktlint.version>3.7.1</ktlint.version>
         <testcontainers.version>2.0.5</testcontainers.version>
         <jena.version>6.0.0</jena.version>
         <avro.version>1.12.1</avro.version>
@@ -366,7 +370,7 @@
             <plugin>
                 <groupId>com.github.gantsign.maven</groupId>
                 <artifactId>ktlint-maven-plugin</artifactId>
-                <version>3.7.1</version>
+                <version>${ktlint.version}</version>
                 <executions>
                     <execution>
                         <id>format-and-check</id>

--- a/src/main/kotlin/no/fdk/harvester/adapter/DefaultOrganizationsAdapter.kt
+++ b/src/main/kotlin/no/fdk/harvester/adapter/DefaultOrganizationsAdapter.kt
@@ -17,9 +17,7 @@ private val logger = LoggerFactory.getLogger(DefaultOrganizationsAdapter::class.
 
 /** HTTP-based implementation of [OrganizationsAdapter] using [ApplicationProperties.organizationsUri]. */
 @Service
-class DefaultOrganizationsAdapter(
-    private val applicationProperties: ApplicationProperties,
-) : OrganizationsAdapter {
+class DefaultOrganizationsAdapter(private val applicationProperties: ApplicationProperties) : OrganizationsAdapter {
     override fun getOrganization(id: String): Organization? {
         val uri = "${applicationProperties.organizationsUri}/$id"
         with(URI(uri).toURL().openConnection() as HttpURLConnection) {

--- a/src/main/kotlin/no/fdk/harvester/config/CircuitBreakerConsumerConfiguration.kt
+++ b/src/main/kotlin/no/fdk/harvester/config/CircuitBreakerConsumerConfiguration.kt
@@ -19,9 +19,7 @@ import java.time.Duration
  * when the breaker opens (e.g. after repeated harvest failures) or closes again.
  */
 @Configuration
-open class CircuitBreakerConsumerConfiguration(
-    private val kafkaManager: KafkaManager,
-) {
+open class CircuitBreakerConsumerConfiguration(private val kafkaManager: KafkaManager) {
     @Bean
     open fun circuitBreakerRegistry(): CircuitBreakerRegistry {
         val defaultConfig =

--- a/src/main/kotlin/no/fdk/harvester/config/MetricsConfiguration.kt
+++ b/src/main/kotlin/no/fdk/harvester/config/MetricsConfiguration.kt
@@ -11,10 +11,7 @@ import org.springframework.context.annotation.Configuration
 
 /** Binds Resilience4j circuit breaker metrics and custom harvest metrics to the application [MeterRegistry]. */
 @Configuration
-open class MetricsConfiguration(
-    private val circuitBreakerRegistry: CircuitBreakerRegistry,
-    private val meterRegistry: MeterRegistry,
-) {
+open class MetricsConfiguration(private val circuitBreakerRegistry: CircuitBreakerRegistry, private val meterRegistry: MeterRegistry) {
     @PostConstruct
     fun bindMetrics() {
         HarvestMetrics.bind(meterRegistry)

--- a/src/main/kotlin/no/fdk/harvester/error/HarvestErrorMessageMapper.kt
+++ b/src/main/kotlin/no/fdk/harvester/error/HarvestErrorMessageMapper.kt
@@ -15,42 +15,41 @@ object HarvestErrorMessageMapper {
         dataSourceUrl: String? = null,
         dataType: DataType? = null,
         originalError: String? = null,
-    ): String =
-        when (category) {
-            HarvestErrorCategory.VALIDATION_ERROR -> {
-                "This harvest could not start because required information is missing or invalid."
-            }
-
-            HarvestErrorCategory.SOURCE_UNAVAILABLE -> {
-                "Unable to harvest data from the source${urlFragment(
-                    dataSourceUrl,
-                )}. Original error message: '$originalError'. Please remedy and/or check that the service is available and try again."
-            }
-
-            HarvestErrorCategory.SOURCE_NOT_FOUND -> {
-                "The configured data source${urlFragment(dataSourceUrl)} was not found. It may have been removed or misconfigured."
-            }
-
-            HarvestErrorCategory.SOURCE_DATA_INVALID -> {
-                "The data from${urlFragment(
-                    dataSourceUrl,
-                )} could not be imported because it is not in a valid format. Please verify the published ${dataTypeFragment(
-                    dataType,
-                )}data."
-            }
-
-            HarvestErrorCategory.SOURCE_CONFLICT -> {
-                originalError?.takeIf { it.isNotBlank() }
-                    ?: (
-                        "A resource present in the source is already harvested from another data source " +
-                            "and cannot be harvested from the current source."
-                    )
-            }
-
-            HarvestErrorCategory.INTERNAL_ERROR -> {
-                "An unexpected error occurred during harvesting. Please try again later or contact support if the problem persists."
-            }
+    ): String = when (category) {
+        HarvestErrorCategory.VALIDATION_ERROR -> {
+            "This harvest could not start because required information is missing or invalid."
         }
+
+        HarvestErrorCategory.SOURCE_UNAVAILABLE -> {
+            "Unable to harvest data from the source${urlFragment(
+                dataSourceUrl,
+            )}. Original error message: '$originalError'. Please remedy and/or check that the service is available and try again."
+        }
+
+        HarvestErrorCategory.SOURCE_NOT_FOUND -> {
+            "The configured data source${urlFragment(dataSourceUrl)} was not found. It may have been removed or misconfigured."
+        }
+
+        HarvestErrorCategory.SOURCE_DATA_INVALID -> {
+            "The data from${urlFragment(
+                dataSourceUrl,
+            )} could not be imported because it is not in a valid format. Please verify the published ${dataTypeFragment(
+                dataType,
+            )}data."
+        }
+
+        HarvestErrorCategory.SOURCE_CONFLICT -> {
+            originalError?.takeIf { it.isNotBlank() }
+                ?: (
+                    "A resource present in the source is already harvested from another data source " +
+                        "and cannot be harvested from the current source."
+                    )
+        }
+
+        HarvestErrorCategory.INTERNAL_ERROR -> {
+            "An unexpected error occurred during harvesting. Please try again later or contact support if the problem persists."
+        }
+    }
 
     private fun urlFragment(url: String?): String = if (url.isNullOrBlank()) "" else " at $url"
 

--- a/src/main/kotlin/no/fdk/harvester/harvester/BaseHarvester.kt
+++ b/src/main/kotlin/no/fdk/harvester/harvester/BaseHarvester.kt
@@ -122,11 +122,11 @@ abstract class BaseHarvester(
                 dataType = dataType,
                 source = source,
                 errorMessage =
-                    HarvestErrorMessageMapper.toUserMessage(
-                        category = HarvestErrorCategory.VALIDATION_ERROR,
-                        dataSourceUrl = source.url,
-                        dataType = null,
-                    ),
+                HarvestErrorMessageMapper.toUserMessage(
+                    category = HarvestErrorCategory.VALIDATION_ERROR,
+                    dataSourceUrl = source.url,
+                    dataType = null,
+                ),
                 errorCategory = HarvestErrorCategory.VALIDATION_ERROR,
                 harvestDate = harvestDate,
                 runId = runId,
@@ -146,11 +146,11 @@ abstract class BaseHarvester(
                         dataType = dataType,
                         source = source,
                         errorMessage =
-                            HarvestErrorMessageMapper.toUserMessage(
-                                category = HarvestErrorCategory.VALIDATION_ERROR,
-                                dataSourceUrl = source.url,
-                                dataType = null,
-                            ),
+                        HarvestErrorMessageMapper.toUserMessage(
+                            category = HarvestErrorCategory.VALIDATION_ERROR,
+                            dataSourceUrl = source.url,
+                            dataType = null,
+                        ),
                         errorCategory = HarvestErrorCategory.VALIDATION_ERROR,
                         harvestDate = harvestDate,
                         runId = runId,
@@ -166,11 +166,11 @@ abstract class BaseHarvester(
                         dataType = dataType,
                         source = source,
                         errorMessage =
-                            HarvestErrorMessageMapper.toUserMessage(
-                                category = HarvestErrorCategory.VALIDATION_ERROR,
-                                dataSourceUrl = source.url,
-                                dataType = null,
-                            ),
+                        HarvestErrorMessageMapper.toUserMessage(
+                            category = HarvestErrorCategory.VALIDATION_ERROR,
+                            dataSourceUrl = source.url,
+                            dataType = null,
+                        ),
                         errorCategory = HarvestErrorCategory.VALIDATION_ERROR,
                         harvestDate = harvestDate,
                         runId = runId,
@@ -204,12 +204,12 @@ abstract class BaseHarvester(
                 dataType = dataType,
                 source = source,
                 errorMessage =
-                    HarvestErrorMessageMapper.toUserMessage(
-                        category = category,
-                        dataSourceUrl = source.url,
-                        dataType = null,
-                        originalError = ex.message,
-                    ),
+                HarvestErrorMessageMapper.toUserMessage(
+                    category = category,
+                    dataSourceUrl = source.url,
+                    dataType = null,
+                    originalError = ex.message,
+                ),
                 errorCategory = category,
                 harvestDate = harvestDate,
                 runId = runId,
@@ -222,11 +222,7 @@ abstract class BaseHarvester(
      * If it exists, returns it as-is (HarvestSource is immutable).
      * If not, creates a new one.
      */
-    protected fun getOrCreateHarvestSource(
-        uri: String,
-        checksum: String,
-        issued: Instant,
-    ): HarvestSourceEntity {
+    protected fun getOrCreateHarvestSource(uri: String, checksum: String, issued: Instant): HarvestSourceEntity {
         val existing = harvestSourceRepository.findByUri(uri)
         return existing
             ?: harvestSourceRepository.save(HarvestSourceEntity(uri = uri, checksum = checksum, issued = issued, initialized = false))
@@ -261,11 +257,7 @@ abstract class BaseHarvester(
      * @param dbResource The existing resource from the database (if any)
      * @throws HarvestSourceConflictException if the resource belongs to another harvest source
      */
-    protected fun validateSourceUrl(
-        resourceUri: String,
-        harvestSource: HarvestSourceEntity,
-        dbResource: ResourceEntity?,
-    ) {
+    protected fun validateSourceUrl(resourceUri: String, harvestSource: HarvestSourceEntity, dbResource: ResourceEntity?) {
         if (dbResource != null && !dbResource.removed && dbResource.harvestSource.id != harvestSource.id) {
             throw HarvestSourceConflictException(
                 "Resource $resourceUri already exists and was harvested from ${dbResource.harvestSource.uri}. " +
@@ -317,10 +309,9 @@ abstract class BaseHarvester(
         type: ResourceType,
         currentUris: Set<String>,
         harvestSource: HarvestSourceEntity,
-    ): List<ResourceEntity> =
-        resourceRepository
-            .findAllByType(type)
-            .filter { it.harvestSource.id == harvestSource.id && !it.removed && !currentUris.contains(it.uri) }
+    ): List<ResourceEntity> = resourceRepository
+        .findAllByType(type)
+        .filter { it.harvestSource.id == harvestSource.id && !it.removed && !currentUris.contains(it.uri) }
 
     /**
      * Type-specific harvest logic: parse RDF into resources, update the database, and build the report.

--- a/src/main/kotlin/no/fdk/harvester/harvester/ConceptHarvester.kt
+++ b/src/main/kotlin/no/fdk/harvester/harvester/ConceptHarvester.kt
@@ -28,18 +28,14 @@ class ConceptHarvester(
     harvestSourceRepository: HarvestSourceRepository,
     resourceEventProducer: ResourceEventProducer,
 ) : ResourceHarvester(
-        harvestSourceRepository,
-        resourceRepository,
-        applicationProperties,
-        orgAdapter,
-        resourceEventProducer,
-    ) {
-    fun harvestConceptCollection(
-        source: HarvestDataSource,
-        harvestDate: Calendar,
-        forceUpdate: Boolean,
-        runId: String,
-    ): HarvestReport? = validateAndHarvest(source, harvestDate, forceUpdate, runId, "concept", requiresAcceptHeader = true)
+    harvestSourceRepository,
+    resourceRepository,
+    applicationProperties,
+    orgAdapter,
+    resourceEventProducer,
+) {
+    fun harvestConceptCollection(source: HarvestDataSource, harvestDate: Calendar, forceUpdate: Boolean, runId: String): HarvestReport? =
+        validateAndHarvest(source, harvestDate, forceUpdate, runId, "concept", requiresAcceptHeader = true)
 
     override val harvestConfig =
         ResourceHarvestConfig(
@@ -59,28 +55,23 @@ class ConceptHarvester(
 
     override fun memberLinkProperty(): Property = SKOS.member
 
-    override fun listMembers(
-        harvested: Model,
-        sourceURL: String,
-    ): List<MemberRDFModel> =
-        harvested
-            .listResourcesWithProperty(RDF.type, SKOS.Concept)
-            .toList()
-            .excludeBlankNodes(sourceURL)
-            .map { it.extractMember(memberLinkProperty()) }
+    override fun listMembers(harvested: Model, sourceURL: String): List<MemberRDFModel> = harvested
+        .listResourcesWithProperty(RDF.type, SKOS.Concept)
+        .toList()
+        .excludeBlankNodes(sourceURL)
+        .map { it.extractMember(memberLinkProperty()) }
 
     override fun extractContainers(
         harvested: Model,
         members: List<MemberRDFModel>,
         sourceURL: String,
         organization: Organization?,
-    ): List<ContainerRDFModel> =
-        extractContainersWithOrphans(
-            harvested = harvested,
-            members = members,
-            sourceURL = sourceURL,
-            organization = organization,
-        )
+    ): List<ContainerRDFModel> = extractContainersWithOrphans(
+        harvested = harvested,
+        members = members,
+        sourceURL = sourceURL,
+        organization = organization,
+    )
 
     override fun isSeparatelyHarvestedMemberType(types: List<RDFNode>): Boolean = types.contains(SKOS.Concept)
 }

--- a/src/main/kotlin/no/fdk/harvester/harvester/DataServiceHarvester.kt
+++ b/src/main/kotlin/no/fdk/harvester/harvester/DataServiceHarvester.kt
@@ -29,18 +29,14 @@ class DataServiceHarvester(
     harvestSourceRepository: HarvestSourceRepository,
     resourceEventProducer: ResourceEventProducer,
 ) : ResourceHarvester(
-        harvestSourceRepository,
-        resourceRepository,
-        applicationProperties,
-        orgAdapter,
-        resourceEventProducer,
-    ) {
-    fun harvestDataServiceCatalog(
-        source: HarvestDataSource,
-        harvestDate: Calendar,
-        forceUpdate: Boolean,
-        runId: String,
-    ): HarvestReport? = validateAndHarvest(source, harvestDate, forceUpdate, runId, "dataservice", requiresAcceptHeader = true)
+    harvestSourceRepository,
+    resourceRepository,
+    applicationProperties,
+    orgAdapter,
+    resourceEventProducer,
+) {
+    fun harvestDataServiceCatalog(source: HarvestDataSource, harvestDate: Calendar, forceUpdate: Boolean, runId: String): HarvestReport? =
+        validateAndHarvest(source, harvestDate, forceUpdate, runId, "dataservice", requiresAcceptHeader = true)
 
     override val harvestConfig =
         ResourceHarvestConfig(
@@ -59,28 +55,23 @@ class DataServiceHarvester(
 
     override fun memberLinkProperty(): Property = DCAT.service
 
-    override fun listMembers(
-        harvested: Model,
-        sourceURL: String,
-    ): List<MemberRDFModel> =
-        harvested
-            .listResourcesWithProperty(RDF.type, DCAT.DataService)
-            .toList()
-            .excludeBlankNodes(sourceURL)
-            .map { it.extractMember(memberLinkProperty()) }
+    override fun listMembers(harvested: Model, sourceURL: String): List<MemberRDFModel> = harvested
+        .listResourcesWithProperty(RDF.type, DCAT.DataService)
+        .toList()
+        .excludeBlankNodes(sourceURL)
+        .map { it.extractMember(memberLinkProperty()) }
 
     override fun extractContainers(
         harvested: Model,
         members: List<MemberRDFModel>,
         sourceURL: String,
         organization: Organization?,
-    ): List<ContainerRDFModel> =
-        extractContainersWithOrphans(
-            harvested = harvested,
-            members = members,
-            sourceURL = sourceURL,
-            organization = organization,
-        )
+    ): List<ContainerRDFModel> = extractContainersWithOrphans(
+        harvested = harvested,
+        members = members,
+        sourceURL = sourceURL,
+        organization = organization,
+    )
 
     override fun isSeparatelyHarvestedMemberType(types: List<RDFNode>): Boolean = types.contains(DCAT.DataService)
 }

--- a/src/main/kotlin/no/fdk/harvester/harvester/DatasetHarvester.kt
+++ b/src/main/kotlin/no/fdk/harvester/harvester/DatasetHarvester.kt
@@ -29,18 +29,14 @@ class DatasetHarvester(
     harvestSourceRepository: HarvestSourceRepository,
     resourceEventProducer: ResourceEventProducer,
 ) : ResourceHarvester(
-        harvestSourceRepository,
-        resourceRepository,
-        applicationProperties,
-        orgAdapter,
-        resourceEventProducer,
-    ) {
-    fun harvestDatasetCatalog(
-        source: HarvestDataSource,
-        harvestDate: Calendar,
-        forceUpdate: Boolean,
-        runId: String,
-    ): HarvestReport? = validateAndHarvest(source, harvestDate, forceUpdate, runId, "dataset", requiresAcceptHeader = true)
+    harvestSourceRepository,
+    resourceRepository,
+    applicationProperties,
+    orgAdapter,
+    resourceEventProducer,
+) {
+    fun harvestDatasetCatalog(source: HarvestDataSource, harvestDate: Calendar, forceUpdate: Boolean, runId: String): HarvestReport? =
+        validateAndHarvest(source, harvestDate, forceUpdate, runId, "dataset", requiresAcceptHeader = true)
 
     override val harvestConfig =
         ResourceHarvestConfig(
@@ -59,10 +55,7 @@ class DatasetHarvester(
 
     override fun memberLinkProperty(): Property = DCAT.dataset
 
-    override fun listMembers(
-        harvested: Model,
-        sourceURL: String,
-    ): List<MemberRDFModel> {
+    override fun listMembers(harvested: Model, sourceURL: String): List<MemberRDFModel> {
         val datasets = harvested.listResourcesWithProperty(RDF.type, DCAT.Dataset).toList()
         val series = harvested.listResourcesWithProperty(RDF.type, DCAT3.DatasetSeries).toList()
         return (datasets + series)
@@ -76,25 +69,24 @@ class DatasetHarvester(
         members: List<MemberRDFModel>,
         sourceURL: String,
         organization: Organization?,
-    ): List<ContainerRDFModel> =
-        extractContainersWithOrphans(
-            harvested = harvested,
-            members = members,
-            sourceURL = sourceURL,
-            organization = organization,
-            resolveContainerMemberUris = { containerResource ->
-                containerResource
-                    .listProperties(memberLinkProperty())
-                    .toList()
-                    .filter { it.isResourceProperty() }
-                    .map { it.resource }
-                    .flatMap { it.expandDatasetSeriesMembers() }
-                    .filter { it.isHarvestableDataset() }
-                    .excludeBlankNodes(sourceURL)
-                    .map { it.uri }
-                    .toSet()
-            },
-        )
+    ): List<ContainerRDFModel> = extractContainersWithOrphans(
+        harvested = harvested,
+        members = members,
+        sourceURL = sourceURL,
+        organization = organization,
+        resolveContainerMemberUris = { containerResource ->
+            containerResource
+                .listProperties(memberLinkProperty())
+                .toList()
+                .filter { it.isResourceProperty() }
+                .map { it.resource }
+                .flatMap { it.expandDatasetSeriesMembers() }
+                .filter { it.isHarvestableDataset() }
+                .excludeBlankNodes(sourceURL)
+                .map { it.uri }
+                .toSet()
+        },
+    )
 
     override fun isSeparatelyHarvestedMemberType(types: List<RDFNode>): Boolean =
         types.contains(DCAT.Dataset) || types.contains(DCAT3.DatasetSeries)

--- a/src/main/kotlin/no/fdk/harvester/harvester/EventHarvester.kt
+++ b/src/main/kotlin/no/fdk/harvester/harvester/EventHarvester.kt
@@ -31,18 +31,14 @@ class EventHarvester(
     harvestSourceRepository: HarvestSourceRepository,
     resourceEventProducer: ResourceEventProducer,
 ) : ResourceHarvester(
-        harvestSourceRepository,
-        resourceRepository,
-        applicationProperties,
-        orgAdapter,
-        resourceEventProducer,
-    ) {
-    fun harvestEvents(
-        source: HarvestDataSource,
-        harvestDate: Calendar,
-        forceUpdate: Boolean,
-        runId: String,
-    ): HarvestReport? = validateAndHarvest(source, harvestDate, forceUpdate, runId, "event", requiresAcceptHeader = true)
+    harvestSourceRepository,
+    resourceRepository,
+    applicationProperties,
+    orgAdapter,
+    resourceEventProducer,
+) {
+    fun harvestEvents(source: HarvestDataSource, harvestDate: Calendar, forceUpdate: Boolean, runId: String): HarvestReport? =
+        validateAndHarvest(source, harvestDate, forceUpdate, runId, "event", requiresAcceptHeader = true)
 
     override val harvestConfig =
         ResourceHarvestConfig(
@@ -61,34 +57,28 @@ class EventHarvester(
 
     override fun memberLinkProperty(): Property = DCATNO.containsEvent
 
-    override fun listMembers(
-        harvested: Model,
-        sourceURL: String,
-    ): List<MemberRDFModel> =
-        harvested
-            .listResourcesWithEventType()
-            .excludeBlankNodes(sourceURL)
-            .map { it.extractMember(memberLinkProperty()) }
+    override fun listMembers(harvested: Model, sourceURL: String): List<MemberRDFModel> = harvested
+        .listResourcesWithEventType()
+        .excludeBlankNodes(sourceURL)
+        .map { it.extractMember(memberLinkProperty()) }
 
     override fun extractContainers(
         harvested: Model,
         members: List<MemberRDFModel>,
         sourceURL: String,
         organization: Organization?,
-    ): List<ContainerRDFModel> =
-        extractContainersWithOrphans(
-            harvested = harvested,
-            members = members,
-            sourceURL = sourceURL,
-            organization = organization,
-        )
+    ): List<ContainerRDFModel> = extractContainersWithOrphans(
+        harvested = harvested,
+        members = members,
+        sourceURL = sourceURL,
+        organization = organization,
+    )
 
-    override fun isSeparatelyHarvestedMemberType(types: List<RDFNode>): Boolean =
-        types.contains(CV.Event) ||
-            types.contains(CV.BusinessEvent) ||
-            types.contains(CV.LifeEvent) ||
-            types.contains(CPSV.PublicService) ||
-            types.contains(CPSVNO.Service)
+    override fun isSeparatelyHarvestedMemberType(types: List<RDFNode>): Boolean = types.contains(CV.Event) ||
+        types.contains(CV.BusinessEvent) ||
+        types.contains(CV.LifeEvent) ||
+        types.contains(CPSV.PublicService) ||
+        types.contains(CPSVNO.Service)
 
     private fun Model.listResourcesWithEventType(): List<Resource> {
         val events = listResourcesWithProperty(RDF.type, CV.Event).toList()

--- a/src/main/kotlin/no/fdk/harvester/harvester/HarvestHelpers.kt
+++ b/src/main/kotlin/no/fdk/harvester/harvester/HarvestHelpers.kt
@@ -39,35 +39,32 @@ internal fun Model.recursiveBlankNodeSkolem(baseURI: String): Model {
     }
 }
 
-private fun Resource.doesNotContainAnon(): Boolean =
-    listProperties()
-        .toList()
-        .filter { it.isResourceProperty() }
-        .map { it.resource }
-        .filter { it.listProperties().toList().size > 0 }
-        .none { it.isAnon }
+private fun Resource.doesNotContainAnon(): Boolean = listProperties()
+    .toList()
+    .filter { it.isResourceProperty() }
+    .map { it.resource }
+    .filter { it.listProperties().toList().size > 0 }
+    .none { it.isAnon }
 
-private fun Resource.createSkolemID(): String =
-    createIdFromString(
-        listProperties()
-            .toModel()
-            .createRDFResponse(Lang.N3)
-            .replace("\\s".toRegex(), "")
-            .toCharArray()
-            .sorted()
-            .toString(),
-    )
+private fun Resource.createSkolemID(): String = createIdFromString(
+    listProperties()
+        .toModel()
+        .createRDFResponse(Lang.N3)
+        .replace("\\s".toRegex(), "")
+        .toCharArray()
+        .sorted()
+        .toString(),
+)
 
 /** Drops blank-node resources (only URI resources can be harvested), logging a warning for each. */
-internal fun List<Resource>.excludeBlankNodes(sourceURL: String): List<Resource> =
-    filter {
-        if (it.isURIResource) {
-            true
-        } else {
-            LOGGER.warn("Blank node resource filtered when harvesting $sourceURL")
-            false
-        }
+internal fun List<Resource>.excludeBlankNodes(sourceURL: String): List<Resource> = filter {
+    if (it.isURIResource) {
+        true
+    } else {
+        LOGGER.warn("Blank node resource filtered when harvesting $sourceURL")
+        false
     }
+}
 
 internal fun Resource.addPublisherForGeneratedCatalog(publisherURI: String?): Resource {
     if (publisherURI != null) {
@@ -76,11 +73,7 @@ internal fun Resource.addPublisherForGeneratedCatalog(publisherURI: String?): Re
     return this
 }
 
-internal fun Resource.addLabelForGeneratedCatalog(
-    organization: Organization?,
-    nbnnSuffix: String,
-    enSuffix: String,
-): Resource {
+internal fun Resource.addLabelForGeneratedCatalog(organization: Organization?, nbnnSuffix: String, enSuffix: String): Resource {
     val nb: String? = organization?.prefLabel?.nb ?: organization?.name
     if (!nb.isNullOrBlank()) addProperty(RDFS.label, model.createLiteral("$nb - $nbnnSuffix", "nb"))
 
@@ -93,22 +86,19 @@ internal fun Resource.addLabelForGeneratedCatalog(
     return this
 }
 
-fun Statement.isResourceProperty(): Boolean =
-    try {
-        resource.isResource
-    } catch (ex: ResourceRequiredException) {
-        false
-    }
+fun Statement.isResourceProperty(): Boolean = try {
+    resource.isResource
+} catch (ex: ResourceRequiredException) {
+    false
+}
 
-fun formatNowWithOsloTimeZone(): String =
-    ZonedDateTime
-        .now(ZoneId.of("Europe/Oslo"))
-        .format(DateTimeFormatter.ofPattern(DATE_FORMAT))
+fun formatNowWithOsloTimeZone(): String = ZonedDateTime
+    .now(ZoneId.of("Europe/Oslo"))
+    .format(DateTimeFormatter.ofPattern(DATE_FORMAT))
 
-fun Calendar.formatWithOsloTimeZone(): String =
-    ZonedDateTime
-        .from(toInstant().atZone(ZoneId.of("Europe/Oslo")))
-        .format(DateTimeFormatter.ofPattern(DATE_FORMAT))
+fun Calendar.formatWithOsloTimeZone(): String = ZonedDateTime
+    .from(toInstant().atZone(ZoneId.of("Europe/Oslo")))
+    .format(DateTimeFormatter.ofPattern(DATE_FORMAT))
 
 fun createResourceEntity(
     uri: String,
@@ -117,27 +107,19 @@ fun createResourceEntity(
     harvestDate: Calendar,
     harvestSource: HarvestSourceEntity,
     dbMeta: ResourceEntity?,
-): ResourceEntity =
-    ResourceEntity(
-        uri = uri,
-        type = type,
-        fdkId = dbMeta?.fdkId ?: createIdFromString(uri),
-        removed = false,
-        issued = dbMeta?.issued ?: harvestDate.toInstant(),
-        modified = harvestDate.toInstant(),
-        checksum = checksum,
-        harvestSource = harvestSource,
-    )
+): ResourceEntity = ResourceEntity(
+    uri = uri,
+    type = type,
+    fdkId = dbMeta?.fdkId ?: createIdFromString(uri),
+    removed = false,
+    issued = dbMeta?.issued ?: harvestDate.toInstant(),
+    modified = harvestDate.toInstant(),
+    checksum = checksum,
+    harvestSource = harvestSource,
+)
 
-fun checksumHasChanged(
-    dbMeta: ResourceEntity?,
-    checksum: String,
-): Boolean = dbMeta == null || checksum != dbMeta.checksum
+fun checksumHasChanged(dbMeta: ResourceEntity?, checksum: String): Boolean = dbMeta == null || checksum != dbMeta.checksum
 
-class HarvestException(
-    url: String,
-) : Exception("Harvest failed for $url")
+class HarvestException(url: String) : Exception("Harvest failed for $url")
 
-class HarvestSourceConflictException(
-    message: String,
-) : Exception(message)
+class HarvestSourceConflictException(message: String) : Exception(message)

--- a/src/main/kotlin/no/fdk/harvester/harvester/HarvestReportBuilder.kt
+++ b/src/main/kotlin/no/fdk/harvester/harvester/HarvestReportBuilder.kt
@@ -19,28 +19,21 @@ object HarvestReportBuilder {
         changedResources: List<FdkIdAndUri>,
         removedResources: List<FdkIdAndUri>,
         runId: String,
-    ): HarvestReport =
-        HarvestReport(
-            runId = runId,
-            dataSourceId = sourceId,
-            dataSourceUrl = sourceUrl,
-            dataType = dataType,
-            harvestError = false,
-            startTime = harvestDate.formatWithOsloTimeZone(),
-            endTime = formatNowWithOsloTimeZone(),
-            changedCatalogs = changedCatalogs,
-            changedResources = changedResources,
-            removedResources = removedResources,
-        )
+    ): HarvestReport = HarvestReport(
+        runId = runId,
+        dataSourceId = sourceId,
+        dataSourceUrl = sourceUrl,
+        dataType = dataType,
+        harvestError = false,
+        startTime = harvestDate.formatWithOsloTimeZone(),
+        endTime = formatNowWithOsloTimeZone(),
+        changedCatalogs = changedCatalogs,
+        changedResources = changedResources,
+        removedResources = removedResources,
+    )
 
     /** Creates a report when no resources were changed or removed. */
-    fun createNoChangeReport(
-        dataType: String,
-        sourceId: String,
-        sourceUrl: String,
-        harvestDate: Calendar,
-        runId: String,
-    ): HarvestReport =
+    fun createNoChangeReport(dataType: String, sourceId: String, sourceUrl: String, harvestDate: Calendar, runId: String): HarvestReport =
         HarvestReport(
             runId = runId,
             dataSourceId = sourceId,
@@ -82,21 +75,20 @@ object HarvestReportBuilder {
         harvestDate: Calendar,
         sourceId: String?,
         sourceUrl: String?,
-    ): HarvestReport =
-        HarvestReport(
-            runId = runId,
-            dataSourceId = sourceId ?: "",
+    ): HarvestReport = HarvestReport(
+        runId = runId,
+        dataSourceId = sourceId ?: "",
+        dataSourceUrl = sourceUrl,
+        dataType = dataType,
+        harvestError = true,
+        errorMessage =
+        HarvestErrorMessageMapper.toUserMessage(
+            category = HarvestErrorCategory.VALIDATION_ERROR,
             dataSourceUrl = sourceUrl,
-            dataType = dataType,
-            harvestError = true,
-            errorMessage =
-                HarvestErrorMessageMapper.toUserMessage(
-                    category = HarvestErrorCategory.VALIDATION_ERROR,
-                    dataSourceUrl = sourceUrl,
-                    dataType = null,
-                ),
-            errorCategory = HarvestErrorCategory.VALIDATION_ERROR,
-            startTime = harvestDate.formatWithOsloTimeZone(),
-            endTime = formatNowWithOsloTimeZone(),
-        )
+            dataType = null,
+        ),
+        errorCategory = HarvestErrorCategory.VALIDATION_ERROR,
+        startTime = harvestDate.formatWithOsloTimeZone(),
+        endTime = formatNowWithOsloTimeZone(),
+    )
 }

--- a/src/main/kotlin/no/fdk/harvester/harvester/InformationModelHarvester.kt
+++ b/src/main/kotlin/no/fdk/harvester/harvester/InformationModelHarvester.kt
@@ -31,12 +31,12 @@ class InformationModelHarvester(
     harvestSourceRepository: HarvestSourceRepository,
     resourceEventProducer: ResourceEventProducer,
 ) : ResourceHarvester(
-        harvestSourceRepository,
-        resourceRepository,
-        applicationProperties,
-        orgAdapter,
-        resourceEventProducer,
-    ) {
+    harvestSourceRepository,
+    resourceRepository,
+    applicationProperties,
+    orgAdapter,
+    resourceEventProducer,
+) {
     fun harvestInformationModelCatalog(
         source: HarvestDataSource,
         harvestDate: Calendar,
@@ -61,36 +61,27 @@ class InformationModelHarvester(
 
     override fun memberLinkProperty(): Property = ModellDCATAPNO.model
 
-    override fun listMembers(
-        harvested: Model,
-        sourceURL: String,
-    ): List<MemberRDFModel> =
-        harvested
-            .listResourcesWithProperty(RDF.type, ModellDCATAPNO.InformationModel)
-            .toList()
-            .excludeBlankNodes(sourceURL)
-            .map { it.extractMember(memberLinkProperty()) }
+    override fun listMembers(harvested: Model, sourceURL: String): List<MemberRDFModel> = harvested
+        .listResourcesWithProperty(RDF.type, ModellDCATAPNO.InformationModel)
+        .toList()
+        .excludeBlankNodes(sourceURL)
+        .map { it.extractMember(memberLinkProperty()) }
 
     override fun extractContainers(
         harvested: Model,
         members: List<MemberRDFModel>,
         sourceURL: String,
         organization: Organization?,
-    ): List<ContainerRDFModel> =
-        extractContainersWithOrphans(
-            harvested = harvested,
-            members = members,
-            sourceURL = sourceURL,
-            organization = organization,
-        )
+    ): List<ContainerRDFModel> = extractContainersWithOrphans(
+        harvested = harvested,
+        members = members,
+        sourceURL = sourceURL,
+        organization = organization,
+    )
 
     override fun isSeparatelyHarvestedMemberType(types: List<RDFNode>): Boolean = types.contains(ModellDCATAPNO.InformationModel)
 
-    override fun postProcessMemberModel(
-        model: Model,
-        resource: Resource,
-        types: List<RDFNode>,
-    ) {
+    override fun postProcessMemberModel(model: Model, resource: Resource, types: List<RDFNode>) {
         if (types.contains(ModellDCATAPNO.CodeList)) {
             model.addCodeElementsAssociatedWithCodeList(resource)
         }

--- a/src/main/kotlin/no/fdk/harvester/harvester/ResourceHarvester.kt
+++ b/src/main/kotlin/no/fdk/harvester/harvester/ResourceHarvester.kt
@@ -31,11 +31,7 @@ import java.util.Calendar
 import no.fdk.harvest.DataType as HarvestDataType
 
 /** A harvested member resource before catalog-record attachment. */
-data class MemberRDFModel(
-    val resourceURI: String,
-    val harvested: Model,
-    val isMemberOfAnyContainer: Boolean,
-)
+data class MemberRDFModel(val resourceURI: String, val harvested: Model, val isMemberOfAnyContainer: Boolean)
 
 /** A DCAT catalog or SKOS collection and its member URIs extracted from the source RDF. */
 data class ContainerRDFModel(
@@ -142,11 +138,11 @@ abstract class ResourceHarvester(
                 resourceGraphs = updateResult.resourceGraphs,
                 runId = runId,
                 catalogGraphs =
-                    catalogGraphsForUpdatedMembers(
-                        updateResult.updatedMembers,
-                        containers,
-                        updateResult.metaRecordModels,
-                    ),
+                catalogGraphsForUpdatedMembers(
+                    updateResult.updatedMembers,
+                    containers,
+                    updateResult.metaRecordModels,
+                ),
             )
         }
 
@@ -161,10 +157,7 @@ abstract class ResourceHarvester(
         return report
     }
 
-    protected open fun resolveOrganization(
-        source: HarvestDataSource,
-        members: List<MemberRDFModel>,
-    ): Organization? {
+    protected open fun resolveOrganization(source: HarvestDataSource, members: List<MemberRDFModel>): Organization? {
         val publisherId = source.publisherId ?: return null
         return if (members.any { !it.isMemberOfAnyContainer }) {
             orgAdapter.getOrganization(publisherId)
@@ -173,10 +166,7 @@ abstract class ResourceHarvester(
         }
     }
 
-    protected abstract fun listMembers(
-        harvested: Model,
-        sourceURL: String,
-    ): List<MemberRDFModel>
+    protected abstract fun listMembers(harvested: Model, sourceURL: String): List<MemberRDFModel>
 
     protected abstract fun extractContainers(
         harvested: Model,
@@ -266,11 +256,11 @@ abstract class ResourceHarvester(
                                 modified = meta.modified,
                                 fdkUriBase = harvestConfig.fdkResourceUriBase,
                                 missingParentLogMessage =
-                                    if (parentFdkUri == null) {
-                                        harvestConfig.missingParentLogMessage(meta.uri)
-                                    } else {
-                                        null
-                                    },
+                                if (parentFdkUri == null) {
+                                    harvestConfig.missingParentLogMessage(meta.uri)
+                                } else {
+                                    null
+                                },
                             )
 
                         val graphString = member.harvested.createRDFResponse(Lang.TURTLE)
@@ -378,11 +368,7 @@ abstract class ResourceHarvester(
         )
     }
 
-    protected fun createModelForGeneratedContainer(
-        containerURI: String,
-        memberUris: Set<String>,
-        organization: Organization?,
-    ): Model {
+    protected fun createModelForGeneratedContainer(containerURI: String, memberUris: Set<String>, organization: Organization?): Model {
         val catalogModel = ModelFactory.createDefaultModel()
         catalogModel
             .createResource(containerURI)
@@ -419,23 +405,19 @@ abstract class ResourceHarvester(
         )
     }
 
-    protected fun Model.addContainerProperties(
-        property: Statement,
-        memberLinkProperty: Property,
-    ): Model =
-        when {
-            property.predicate != memberLinkProperty && property.isResourceProperty() -> {
-                add(property).recursiveAddNonMemberResource(property.resource)
-            }
-
-            property.predicate != memberLinkProperty -> {
-                add(property)
-            }
-
-            else -> {
-                this
-            }
+    protected fun Model.addContainerProperties(property: Statement, memberLinkProperty: Property): Model = when {
+        property.predicate != memberLinkProperty && property.isResourceProperty() -> {
+            add(property).recursiveAddNonMemberResource(property.resource)
         }
+
+        property.predicate != memberLinkProperty -> {
+            add(property)
+        }
+
+        else -> {
+            this
+        }
+    }
 
     protected fun Model.recursiveAddNonMemberResource(resource: Resource): Model {
         val types = resource.listProperties(RDF.type).toList().map { it.`object` }
@@ -481,21 +463,13 @@ abstract class ResourceHarvester(
      * present in the target model. The URI-presence check both de-duplicates and breaks cycles
      * (e.g. a resource referencing itself via dct:identifier).
      */
-    private fun Model.shouldAddToTargetModel(
-        resource: Resource,
-        types: List<RDFNode>,
-    ): Boolean =
-        when {
-            isSeparatelyHarvestedMemberType(types) -> false
-            resource.isURIResource && containsTriple("<${resource.uri}>", "?p", "?o") -> false
-            else -> true
-        }
+    private fun Model.shouldAddToTargetModel(resource: Resource, types: List<RDFNode>): Boolean = when {
+        isSeparatelyHarvestedMemberType(types) -> false
+        resource.isURIResource && containsTriple("<${resource.uri}>", "?p", "?o") -> false
+        else -> true
+    }
 
-    protected open fun postProcessMemberModel(
-        model: Model,
-        resource: Resource,
-        types: List<RDFNode>,
-    ) {}
+    protected open fun postProcessMemberModel(model: Model, resource: Resource, types: List<RDFNode>) {}
 
     /**
      * Whether [types] identifies a resource that is harvested as its own member (and therefore must

--- a/src/main/kotlin/no/fdk/harvester/harvester/ServiceHarvester.kt
+++ b/src/main/kotlin/no/fdk/harvester/harvester/ServiceHarvester.kt
@@ -32,18 +32,14 @@ class ServiceHarvester(
     harvestSourceRepository: HarvestSourceRepository,
     resourceEventProducer: ResourceEventProducer,
 ) : ResourceHarvester(
-        harvestSourceRepository,
-        resourceRepository,
-        applicationProperties,
-        orgAdapter,
-        resourceEventProducer,
-    ) {
-    fun harvestServices(
-        source: HarvestDataSource,
-        harvestDate: Calendar,
-        forceUpdate: Boolean,
-        runId: String,
-    ): HarvestReport? = validateAndHarvest(source, harvestDate, forceUpdate, runId, "service", requiresAcceptHeader = true)
+    harvestSourceRepository,
+    resourceRepository,
+    applicationProperties,
+    orgAdapter,
+    resourceEventProducer,
+) {
+    fun harvestServices(source: HarvestDataSource, harvestDate: Calendar, forceUpdate: Boolean, runId: String): HarvestReport? =
+        validateAndHarvest(source, harvestDate, forceUpdate, runId, "service", requiresAcceptHeader = true)
 
     override val harvestConfig =
         ResourceHarvestConfig(
@@ -62,40 +58,30 @@ class ServiceHarvester(
 
     override fun memberLinkProperty(): Property = DCATNO.containsService
 
-    override fun listMembers(
-        harvested: Model,
-        sourceURL: String,
-    ): List<MemberRDFModel> =
-        harvested
-            .listResourcesWithServiceType()
-            .excludeBlankNodes(sourceURL)
-            .map { it.extractMember(memberLinkProperty()) }
+    override fun listMembers(harvested: Model, sourceURL: String): List<MemberRDFModel> = harvested
+        .listResourcesWithServiceType()
+        .excludeBlankNodes(sourceURL)
+        .map { it.extractMember(memberLinkProperty()) }
 
     override fun extractContainers(
         harvested: Model,
         members: List<MemberRDFModel>,
         sourceURL: String,
         organization: Organization?,
-    ): List<ContainerRDFModel> =
-        extractContainersWithOrphans(
-            harvested = harvested,
-            members = members,
-            sourceURL = sourceURL,
-            organization = organization,
-        )
+    ): List<ContainerRDFModel> = extractContainersWithOrphans(
+        harvested = harvested,
+        members = members,
+        sourceURL = sourceURL,
+        organization = organization,
+    )
 
-    override fun isSeparatelyHarvestedMemberType(types: List<RDFNode>): Boolean =
-        types.contains(CPSV.PublicService) ||
-            types.contains(CPSVNO.Service) ||
-            types.contains(CV.Event) ||
-            types.contains(CV.BusinessEvent) ||
-            types.contains(CV.LifeEvent)
+    override fun isSeparatelyHarvestedMemberType(types: List<RDFNode>): Boolean = types.contains(CPSV.PublicService) ||
+        types.contains(CPSVNO.Service) ||
+        types.contains(CV.Event) ||
+        types.contains(CV.BusinessEvent) ||
+        types.contains(CV.LifeEvent)
 
-    override fun postProcessMemberModel(
-        model: Model,
-        resource: Resource,
-        types: List<RDFNode>,
-    ) {
+    override fun postProcessMemberModel(model: Model, resource: Resource, types: List<RDFNode>) {
         if (types.contains(CV.Participation)) {
             model.addAgentsAssociatedWithParticipation(resource)
         }

--- a/src/main/kotlin/no/fdk/harvester/kafka/HarvestEventProducer.kt
+++ b/src/main/kotlin/no/fdk/harvester/kafka/HarvestEventProducer.kt
@@ -24,10 +24,7 @@ class HarvestEventProducer(
      * Builds a HARVESTING phase event from an initiating event and optional report, and sends it to the topic.
      * @return the send future, or null if runId is missing or send fails
      */
-    fun produceHarvestingEvent(
-        initiatingEvent: HarvestEvent,
-        report: HarvestReport?,
-    ): CompletableFuture<*>? {
+    fun produceHarvestingEvent(initiatingEvent: HarvestEvent, report: HarvestReport?): CompletableFuture<*>? {
         return try {
             if (initiatingEvent.runId == null) {
                 logger.error("Initiating event is missing runId, cannot produce harvesting event")

--- a/src/main/kotlin/no/fdk/harvester/kafka/KafkaHarvestEventConsumer.kt
+++ b/src/main/kotlin/no/fdk/harvester/kafka/KafkaHarvestEventConsumer.kt
@@ -18,9 +18,7 @@ import java.time.Duration
  * events by delegating to [KafkaHarvestEventCircuitBreaker]; other phases are skipped.
  */
 @Component
-class KafkaHarvestEventConsumer(
-    private val circuitBreaker: KafkaHarvestEventCircuitBreakerApi,
-) {
+class KafkaHarvestEventConsumer(private val circuitBreaker: KafkaHarvestEventCircuitBreakerApi) {
     private fun logger(): Logger = LOGGER
 
     @KafkaListener(
@@ -29,10 +27,7 @@ class KafkaHarvestEventConsumer(
         containerFactory = "kafkaListenerContainerFactory",
         id = HARVEST_LISTENER_ID,
     )
-    fun consumeHarvestEvent(
-        record: ConsumerRecord<String, HarvestEvent>,
-        ack: Acknowledgment,
-    ) {
+    fun consumeHarvestEvent(record: ConsumerRecord<String, HarvestEvent>, ack: Acknowledgment) {
         logger().debug("Received harvest event - offset: ${record.offset()}, partition: ${record.partition()}")
 
         val event = record.value()

--- a/src/main/kotlin/no/fdk/harvester/kafka/KafkaManager.kt
+++ b/src/main/kotlin/no/fdk/harvester/kafka/KafkaManager.kt
@@ -9,9 +9,7 @@ import org.springframework.stereotype.Component
  * Pauses and resumes Kafka listener containers by listener id (used when circuit breaker opens/closes).
  */
 @Component
-class KafkaManager(
-    private val registry: KafkaListenerEndpointRegistry,
-) {
+class KafkaManager(private val registry: KafkaListenerEndpointRegistry) {
     fun pause(id: String) {
         LOGGER.debug("Pausing kafka listener containers with id: $id")
         registry.listenerContainers

--- a/src/main/kotlin/no/fdk/harvester/kafka/ResourceEventProducer.kt
+++ b/src/main/kotlin/no/fdk/harvester/kafka/ResourceEventProducer.kt
@@ -60,11 +60,7 @@ class ResourceEventProducer(
         publishEvents(dataType, resources, runId, ResourceEventKind.HARVESTED, resourceGraphs, catalogGraphs)
     }
 
-    fun publishRemovedEvents(
-        dataType: DataType,
-        resources: List<FdkIdAndUri>,
-        runId: String,
-    ) {
+    fun publishRemovedEvents(dataType: DataType, resources: List<FdkIdAndUri>, runId: String) {
         publishEvents(dataType, resources, runId, ResourceEventKind.REMOVED)
     }
 
@@ -107,11 +103,11 @@ class ResourceEventProducer(
                             dataType = dataType,
                             kind = kind.toMetricsKind(),
                             outcome =
-                                if (ex == null) {
-                                    PublishOutcome.SUCCESS
-                                } else {
-                                    PublishOutcome.PUBLISH_FAILED
-                                },
+                            if (ex == null) {
+                                PublishOutcome.SUCCESS
+                            } else {
+                                PublishOutcome.PUBLISH_FAILED
+                            },
                         )
                         if (ex == null) {
                             logProducedResourceEvent(
@@ -144,11 +140,10 @@ class ResourceEventProducer(
         }
     }
 
-    private fun ResourceEventKind.toMetricsKind(): ResourceEventMetrics.ResourceEventKind =
-        when (this) {
-            ResourceEventKind.HARVESTED -> ResourceEventMetrics.ResourceEventKind.HARVESTED
-            ResourceEventKind.REMOVED -> ResourceEventMetrics.ResourceEventKind.REMOVED
-        }
+    private fun ResourceEventKind.toMetricsKind(): ResourceEventMetrics.ResourceEventKind = when (this) {
+        ResourceEventKind.HARVESTED -> ResourceEventMetrics.ResourceEventKind.HARVESTED
+        ResourceEventKind.REMOVED -> ResourceEventMetrics.ResourceEventKind.REMOVED
+    }
 
     private fun buildEvent(
         dataType: DataType,

--- a/src/main/kotlin/no/fdk/harvester/metrics/HarvestMetrics.kt
+++ b/src/main/kotlin/no/fdk/harvester/metrics/HarvestMetrics.kt
@@ -113,10 +113,7 @@ object HarvestMetrics {
         recordErrorCount(category = category, dataType = dataType)
     }
 
-    fun recordErrorCount(
-        category: HarvestErrorCategory,
-        dataType: DataType,
-    ) {
+    fun recordErrorCount(category: HarvestErrorCategory, dataType: DataType) {
         registry
             .counter(
                 "harvest_error_count",
@@ -127,10 +124,9 @@ object HarvestMetrics {
             ).increment()
     }
 
-    fun metricType(dataType: DataType): String =
-        when (dataType) {
-            DataType.informationmodel -> "information-model"
-            DataType.publicService, DataType.service -> "public-service"
-            else -> dataType.name
-        }
+    fun metricType(dataType: DataType): String = when (dataType) {
+        DataType.informationmodel -> "information-model"
+        DataType.publicService, DataType.service -> "public-service"
+        else -> dataType.name
+    }
 }

--- a/src/main/kotlin/no/fdk/harvester/metrics/KafkaHarvestMetrics.kt
+++ b/src/main/kotlin/no/fdk/harvester/metrics/KafkaHarvestMetrics.kt
@@ -20,10 +20,7 @@ object KafkaHarvestMetrics {
         ensureListenerPausedGaugeRegistered()
     }
 
-    fun recordEventProcessed(
-        phase: HarvestPhase,
-        result: EventProcessingResult,
-    ) {
+    fun recordEventProcessed(phase: HarvestPhase, result: EventProcessingResult) {
         registry
             .counter(
                 "harvest_event_processing_total",
@@ -49,9 +46,7 @@ object KafkaHarvestMetrics {
         }
     }
 
-    enum class EventProcessingResult(
-        val label: String,
-    ) {
+    enum class EventProcessingResult(val label: String) {
         ACKED("acked"),
         NACKED("nacked"),
         SKIPPED("skipped"),

--- a/src/main/kotlin/no/fdk/harvester/metrics/ResourceEventMetrics.kt
+++ b/src/main/kotlin/no/fdk/harvester/metrics/ResourceEventMetrics.kt
@@ -11,11 +11,7 @@ object ResourceEventMetrics {
         this.registry = registry
     }
 
-    fun recordPublish(
-        dataType: DataType,
-        kind: ResourceEventKind,
-        outcome: PublishOutcome,
-    ) {
+    fun recordPublish(dataType: DataType, kind: ResourceEventKind, outcome: PublishOutcome) {
         registry
             .counter(
                 "resource_event_publish_total",
@@ -30,17 +26,12 @@ object ResourceEventMetrics {
             ).increment()
     }
 
-    enum class ResourceEventKind(
-        val label: String,
-    ) {
+    enum class ResourceEventKind(val label: String) {
         HARVESTED("harvested"),
         REMOVED("removed"),
     }
 
-    enum class PublishOutcome(
-        val status: String,
-        val reason: String,
-    ) {
+    enum class PublishOutcome(val status: String, val reason: String) {
         SUCCESS("success", "published"),
         PUBLISH_FAILED("error", "publish_failed"),
         TOPIC_NOT_CONFIGURED("error", "topic_not_configured"),

--- a/src/main/kotlin/no/fdk/harvester/model/ContentType.kt
+++ b/src/main/kotlin/no/fdk/harvester/model/ContentType.kt
@@ -1,8 +1,6 @@
 package no.fdk.harvester.model
 
-enum class ContentType(
-    vararg val headers: String,
-) {
+enum class ContentType(vararg val headers: String) {
     TURTLE("text/turtle", "application/turtle"),
     N3("text/rdf+n3", "application/n3", "text/n3"),
     TRIG("application/trig", "text/trig"),

--- a/src/main/kotlin/no/fdk/harvester/model/DuplicateIRI.kt
+++ b/src/main/kotlin/no/fdk/harvester/model/DuplicateIRI.kt
@@ -1,7 +1,3 @@
 package no.fdk.harvester.model
 
-data class DuplicateIRI(
-    val iriToRemove: String,
-    val iriToRetain: String,
-    val keepRemovedFdkId: Boolean = false,
-)
+data class DuplicateIRI(val iriToRemove: String, val iriToRetain: String, val keepRemovedFdkId: Boolean = false)

--- a/src/main/kotlin/no/fdk/harvester/model/HarvestDataSource.kt
+++ b/src/main/kotlin/no/fdk/harvester/model/HarvestDataSource.kt
@@ -18,8 +18,4 @@ data class HarvestDataSource(
 
 /** Optional HTTP auth header (type and value) for harvesting protected sources. */
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class AuthHeader(
-    val name: String? = null,
-    val type: String? = null,
-    val value: String? = null,
-)
+data class AuthHeader(val name: String? = null, val type: String? = null, val value: String? = null)

--- a/src/main/kotlin/no/fdk/harvester/model/HarvestReport.kt
+++ b/src/main/kotlin/no/fdk/harvester/model/HarvestReport.kt
@@ -26,7 +26,4 @@ data class HarvestReport(
 /**
  * FDK identifier and URI for a harvested or removed resource.
  */
-data class FdkIdAndUri(
-    val fdkId: String,
-    val uri: String,
-)
+data class FdkIdAndUri(val fdkId: String, val uri: String)

--- a/src/main/kotlin/no/fdk/harvester/model/Organization.kt
+++ b/src/main/kotlin/no/fdk/harvester/model/Organization.kt
@@ -11,8 +11,4 @@ data class Organization(
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-data class PrefLabel(
-    val nb: String? = null,
-    val nn: String? = null,
-    val en: String? = null,
-)
+data class PrefLabel(val nb: String? = null, val nn: String? = null, val en: String? = null)

--- a/src/main/kotlin/no/fdk/harvester/rdf/RDFUtils.kt
+++ b/src/main/kotlin/no/fdk/harvester/rdf/RDFUtils.kt
@@ -42,34 +42,24 @@ fun jenaTypeFromAcceptHeader(accept: String?): Lang? {
     }
 }
 
-fun safeParseRDF(
-    rdf: String,
-    lang: Lang,
-): Model =
-    try {
-        parseRDF(rdf, lang)
-    } catch (ex: Exception) {
-        logger.warn("parse failure", ex)
-        ModelFactory.createDefaultModel()
-    }
+fun safeParseRDF(rdf: String, lang: Lang): Model = try {
+    parseRDF(rdf, lang)
+} catch (ex: Exception) {
+    logger.warn("parse failure", ex)
+    ModelFactory.createDefaultModel()
+}
 
-fun Model.createRDFResponse(responseType: Lang): String =
-    ByteArrayOutputStream().use { out ->
-        write(out, responseType.name)
-        out.flush()
-        out.toString("UTF-8")
-    }
+fun Model.createRDFResponse(responseType: Lang): String = ByteArrayOutputStream().use { out ->
+    write(out, responseType.name)
+    out.flush()
+    out.toString("UTF-8")
+}
 
-fun createIdFromString(idBase: String): String =
-    UUID
-        .nameUUIDFromBytes(idBase.toByteArray())
-        .toString()
+fun createIdFromString(idBase: String): String = UUID
+    .nameUUIDFromBytes(idBase.toByteArray())
+    .toString()
 
-fun Model.containsTriple(
-    subj: String,
-    pred: String,
-    obj: String,
-): Boolean {
+fun Model.containsTriple(subj: String, pred: String, obj: String): Boolean {
     val askQuery = "ASK { $subj $pred $obj }"
 
     return try {
@@ -80,20 +70,13 @@ fun Model.containsTriple(
     }
 }
 
-fun Resource.safeAddProperty(
-    property: Property,
-    value: String?,
-): Resource =
-    if (value.isNullOrEmpty()) {
-        this
-    } else {
-        addProperty(property, model.createResource(value))
-    }
+fun Resource.safeAddProperty(property: Property, value: String?): Resource = if (value.isNullOrEmpty()) {
+    this
+} else {
+    addProperty(property, model.createResource(value))
+}
 
-fun parseRDF(
-    responseBody: String,
-    rdfLanguage: Lang,
-): Model {
+fun parseRDF(responseBody: String, rdfLanguage: Lang): Model {
     val responseModel = ModelFactory.createDefaultModel()
     responseModel.read(StringReader(responseBody), BACKUP_BASE_URI, rdfLanguage.name)
 

--- a/src/main/kotlin/no/fdk/harvester/repository/ResourceRepository.kt
+++ b/src/main/kotlin/no/fdk/harvester/repository/ResourceRepository.kt
@@ -10,10 +10,7 @@ import org.springframework.stereotype.Repository
 interface ResourceRepository : JpaRepository<ResourceEntity, String> {
     fun findAllByType(type: ResourceType): List<ResourceEntity>
 
-    fun findAllByTypeAndRemoved(
-        type: ResourceType,
-        removed: Boolean,
-    ): List<ResourceEntity>
+    fun findAllByTypeAndRemoved(type: ResourceType, removed: Boolean): List<ResourceEntity>
 
     fun findByFdkId(fdkId: String): ResourceEntity?
 

--- a/src/main/kotlin/no/fdk/harvester/service/HarvestService.kt
+++ b/src/main/kotlin/no/fdk/harvester/service/HarvestService.kt
@@ -136,11 +136,11 @@ open class HarvestService(
                         dataType = dataType.name.lowercase(),
                         source = dataSource,
                         errorMessage =
-                            HarvestErrorMessageMapper.toUserMessage(
-                                category = HarvestErrorCategory.INTERNAL_ERROR,
-                                dataSourceUrl = dataSourceUrl,
-                                dataType = dataType,
-                            ),
+                        HarvestErrorMessageMapper.toUserMessage(
+                            category = HarvestErrorCategory.INTERNAL_ERROR,
+                            dataSourceUrl = dataSourceUrl,
+                            dataType = dataType,
+                        ),
                         errorCategory = HarvestErrorCategory.INTERNAL_ERROR,
                         harvestDate = harvestDate,
                         runId = runId,
@@ -171,12 +171,7 @@ open class HarvestService(
      * @return HarvestReport containing information about the deletion operation
      */
     @Transactional
-    override fun markResourcesAsDeleted(
-        sourceUrl: String,
-        dataType: DataType,
-        dataSourceId: String,
-        runId: String,
-    ): HarvestReport {
+    override fun markResourcesAsDeleted(sourceUrl: String, dataType: DataType, dataSourceId: String, runId: String): HarvestReport {
         logger.debug("Marking resources as deleted for sourceUrl: $sourceUrl, dataType: $dataType")
 
         val harvestSource =
@@ -194,7 +189,7 @@ open class HarvestService(
                         matchesDataType(resource.type, dataType) ||
                             resource.type == ResourceType.CATALOG ||
                             resource.type == ResourceType.COLLECTION
-                    )
+                        )
             }
 
         val removedResources =
@@ -251,39 +246,31 @@ open class HarvestService(
         )
     }
 
-    private fun markRemoved(
-        resource: ResourceEntity,
-        modified: Instant,
-    ): ResourceEntity =
-        resourceRepository.save(
-            ResourceEntity(
-                uri = resource.uri,
-                type = resource.type,
-                fdkId = resource.fdkId,
-                removed = true,
-                issued = resource.issued,
-                modified = modified,
-                checksum = resource.checksum,
-                harvestSource = resource.harvestSource,
-            ),
-        )
+    private fun markRemoved(resource: ResourceEntity, modified: Instant): ResourceEntity = resourceRepository.save(
+        ResourceEntity(
+            uri = resource.uri,
+            type = resource.type,
+            fdkId = resource.fdkId,
+            removed = true,
+            issued = resource.issued,
+            modified = modified,
+            checksum = resource.checksum,
+            harvestSource = resource.harvestSource,
+        ),
+    )
 
     /**
      * Checks if a ResourceType matches the given DataType.
      * CATALOG and COLLECTION are metadata types and don't match any DataType.
      */
-    private fun matchesDataType(
-        resourceType: ResourceType,
-        dataType: DataType,
-    ): Boolean =
-        when (dataType) {
-            DataType.concept -> resourceType == ResourceType.CONCEPT
-            DataType.dataset -> resourceType == ResourceType.DATASET
-            DataType.dataservice -> resourceType == ResourceType.DATASERVICE
-            DataType.informationmodel -> resourceType == ResourceType.INFORMATIONMODEL
-            DataType.service, DataType.publicService -> resourceType == ResourceType.SERVICE
-            DataType.event -> resourceType == ResourceType.EVENT
-        }
+    private fun matchesDataType(resourceType: ResourceType, dataType: DataType): Boolean = when (dataType) {
+        DataType.concept -> resourceType == ResourceType.CONCEPT
+        DataType.dataset -> resourceType == ResourceType.DATASET
+        DataType.dataservice -> resourceType == ResourceType.DATASERVICE
+        DataType.informationmodel -> resourceType == ResourceType.INFORMATIONMODEL
+        DataType.service, DataType.publicService -> resourceType == ResourceType.SERVICE
+        DataType.event -> resourceType == ResourceType.EVENT
+    }
 
     companion object {
         private val logger: Logger = LoggerFactory.getLogger(HarvestService::class.java)

--- a/src/test/kotlin/no/fdk/harvester/harvester/BaseHarvesterTest.kt
+++ b/src/test/kotlin/no/fdk/harvester/harvester/BaseHarvesterTest.kt
@@ -153,10 +153,8 @@ class BaseHarvesterTest {
     }
 
     // Test implementation of BaseHarvester for testing
-    private class TestHarvester(
-        harvestSourceRepository: HarvestSourceRepository,
-        resourceRepository: ResourceRepository,
-    ) : BaseHarvester(harvestSourceRepository, resourceRepository) {
+    private class TestHarvester(harvestSourceRepository: HarvestSourceRepository, resourceRepository: ResourceRepository) :
+        BaseHarvester(harvestSourceRepository, resourceRepository) {
         override fun updateDB(
             harvested: org.apache.jena.rdf.model.Model,
             source: HarvestDataSource,
@@ -165,29 +163,22 @@ class BaseHarvesterTest {
             runId: String,
             dataType: String,
             harvestSource: HarvestSourceEntity,
-        ): HarvestReport =
-            HarvestReportBuilder.createSuccessReport(
-                dataType = dataType,
-                sourceId = source.id!!,
-                sourceUrl = source.url!!,
-                harvestDate = harvestDate,
-                changedCatalogs = emptyList(),
-                changedResources = emptyList(),
-                removedResources = emptyList(),
-                runId = runId,
-            )
+        ): HarvestReport = HarvestReportBuilder.createSuccessReport(
+            dataType = dataType,
+            sourceId = source.id!!,
+            sourceUrl = source.url!!,
+            harvestDate = harvestDate,
+            changedCatalogs = emptyList(),
+            changedResources = emptyList(),
+            removedResources = emptyList(),
+            runId = runId,
+        )
 
         // Expose protected methods for testing
-        fun testGetOrCreateHarvestSource(
-            uri: String,
-            checksum: String,
-            issued: Instant,
-        ): HarvestSourceEntity = getOrCreateHarvestSource(uri, checksum, issued)
+        fun testGetOrCreateHarvestSource(uri: String, checksum: String, issued: Instant): HarvestSourceEntity =
+            getOrCreateHarvestSource(uri, checksum, issued)
 
-        fun testValidateSourceUrl(
-            resourceUri: String,
-            harvestSource: HarvestSourceEntity,
-            dbResource: ResourceEntity?,
-        ) = validateSourceUrl(resourceUri, harvestSource, dbResource)
+        fun testValidateSourceUrl(resourceUri: String, harvestSource: HarvestSourceEntity, dbResource: ResourceEntity?) =
+            validateSourceUrl(resourceUri, harvestSource, dbResource)
     }
 }

--- a/src/test/kotlin/no/fdk/harvester/harvester/BaseHarvesterValidationTest.kt
+++ b/src/test/kotlin/no/fdk/harvester/harvester/BaseHarvesterValidationTest.kt
@@ -73,11 +73,11 @@ class BaseHarvesterValidationTest {
             val report =
                 harvester.harvest(
                     source =
-                        HarvestDataSource(
-                            id = "s1",
-                            url = "http://localhost:${server.port()}/rdf",
-                            acceptHeaderValue = "*/*",
-                        ),
+                    HarvestDataSource(
+                        id = "s1",
+                        url = "http://localhost:${server.port()}/rdf",
+                        acceptHeaderValue = "*/*",
+                    ),
                     harvestDate = Calendar.getInstance(),
                 )
 
@@ -101,11 +101,11 @@ class BaseHarvesterValidationTest {
             val report =
                 harvester.harvest(
                     source =
-                        HarvestDataSource(
-                            id = "s1",
-                            url = "http://localhost:${server.port()}/rdf",
-                            acceptHeaderValue = "application/unknown",
-                        ),
+                    HarvestDataSource(
+                        id = "s1",
+                        url = "http://localhost:${server.port()}/rdf",
+                        acceptHeaderValue = "application/unknown",
+                    ),
                     harvestDate = Calendar.getInstance(),
                 )
 
@@ -129,11 +129,11 @@ class BaseHarvesterValidationTest {
             val report =
                 harvester.harvest(
                     source =
-                        HarvestDataSource(
-                            id = "s1",
-                            url = "http://localhost:${server.port()}/rdf",
-                            acceptHeaderValue = "text/turtle",
-                        ),
+                    HarvestDataSource(
+                        id = "s1",
+                        url = "http://localhost:${server.port()}/rdf",
+                        acceptHeaderValue = "text/turtle",
+                    ),
                     harvestDate = Calendar.getInstance(),
                 )
 
@@ -173,11 +173,11 @@ class BaseHarvesterValidationTest {
             val report =
                 harvester.harvest(
                     source =
-                        HarvestDataSource(
-                            id = "s1",
-                            url = "http://localhost:${server.port()}/rdf",
-                            acceptHeaderValue = "text/turtle",
-                        ),
+                    HarvestDataSource(
+                        id = "s1",
+                        url = "http://localhost:${server.port()}/rdf",
+                        acceptHeaderValue = "text/turtle",
+                    ),
                     harvestDate = Calendar.getInstance(),
                 )
 
@@ -217,12 +217,12 @@ class BaseHarvesterValidationTest {
             val report =
                 harvester.harvest(
                     source =
-                        HarvestDataSource(
-                            id = "s1",
-                            url = "http://localhost:${server.port()}/rdf",
-                            acceptHeaderValue = "text/turtle",
-                            authHeader = AuthHeader(type = "X-Auth-Token", value = "secret"),
-                        ),
+                    HarvestDataSource(
+                        id = "s1",
+                        url = "http://localhost:${server.port()}/rdf",
+                        acceptHeaderValue = "text/turtle",
+                        authHeader = AuthHeader(type = "X-Auth-Token", value = "secret"),
+                    ),
                     harvestDate = Calendar.getInstance(),
                 )
 
@@ -254,11 +254,11 @@ class BaseHarvesterValidationTest {
             val report =
                 harvester.harvest(
                     source =
-                        HarvestDataSource(
-                            id = "s1",
-                            url = "http://localhost:${server.port()}/rdf",
-                            acceptHeaderValue = "text/turtle",
-                        ),
+                    HarvestDataSource(
+                        id = "s1",
+                        url = "http://localhost:${server.port()}/rdf",
+                        acceptHeaderValue = "text/turtle",
+                    ),
                     harvestDate = Calendar.getInstance(),
                 )
 
@@ -269,14 +269,9 @@ class BaseHarvesterValidationTest {
         }
     }
 
-    private class TestHarvester(
-        harvestSourceRepository: HarvestSourceRepository,
-        resourceRepository: ResourceRepository,
-    ) : BaseHarvester(harvestSourceRepository, resourceRepository) {
-        fun harvest(
-            source: HarvestDataSource,
-            harvestDate: Calendar,
-        ): HarvestReport? =
+    private class TestHarvester(harvestSourceRepository: HarvestSourceRepository, resourceRepository: ResourceRepository) :
+        BaseHarvester(harvestSourceRepository, resourceRepository) {
+        fun harvest(source: HarvestDataSource, harvestDate: Calendar): HarvestReport? =
             validateAndHarvest(source, harvestDate, forceUpdate = false, runId = "run-1", dataType = "test", requiresAcceptHeader = true)
 
         override fun updateDB(
@@ -287,16 +282,15 @@ class BaseHarvesterValidationTest {
             runId: String,
             dataType: String,
             harvestSource: HarvestSourceEntity,
-        ): HarvestReport =
-            HarvestReportBuilder.createSuccessReport(
-                dataType = dataType,
-                sourceId = source.id!!,
-                sourceUrl = source.url!!,
-                harvestDate = harvestDate,
-                changedCatalogs = emptyList(),
-                changedResources = emptyList(),
-                removedResources = emptyList(),
-                runId = runId,
-            )
+        ): HarvestReport = HarvestReportBuilder.createSuccessReport(
+            dataType = dataType,
+            sourceId = source.id!!,
+            sourceUrl = source.url!!,
+            harvestDate = harvestDate,
+            changedCatalogs = emptyList(),
+            changedResources = emptyList(),
+            removedResources = emptyList(),
+            runId = runId,
+        )
     }
 }

--- a/src/test/kotlin/no/fdk/harvester/harvester/HarvesterHappyPathTest.kt
+++ b/src/test/kotlin/no/fdk/harvester/harvester/HarvesterHappyPathTest.kt
@@ -61,11 +61,11 @@ class HarvesterHappyPathTest {
             val report =
                 harvester.harvestDatasetCatalog(
                     source =
-                        HarvestDataSource(
-                            id = "source-1",
-                            url = "http://localhost:${server.port()}/rdf",
-                            acceptHeaderValue = "text/turtle",
-                        ),
+                    HarvestDataSource(
+                        id = "source-1",
+                        url = "http://localhost:${server.port()}/rdf",
+                        acceptHeaderValue = "text/turtle",
+                    ),
                     harvestDate = Calendar.getInstance(),
                     forceUpdate = false,
                     runId = "run-1",
@@ -141,11 +141,11 @@ class HarvesterHappyPathTest {
             val report =
                 harvester.harvestDatasetCatalog(
                     source =
-                        HarvestDataSource(
-                            id = "source-1",
-                            url = "http://localhost:${server.port()}/rdf",
-                            acceptHeaderValue = "text/turtle",
-                        ),
+                    HarvestDataSource(
+                        id = "source-1",
+                        url = "http://localhost:${server.port()}/rdf",
+                        acceptHeaderValue = "text/turtle",
+                    ),
                     harvestDate = Calendar.getInstance(),
                     forceUpdate = false,
                     runId = "run-1",
@@ -186,11 +186,11 @@ class HarvesterHappyPathTest {
             val report =
                 harvester.harvestDataServiceCatalog(
                     source =
-                        HarvestDataSource(
-                            id = "source-1",
-                            url = "http://localhost:${server.port()}/rdf",
-                            acceptHeaderValue = "text/turtle",
-                        ),
+                    HarvestDataSource(
+                        id = "source-1",
+                        url = "http://localhost:${server.port()}/rdf",
+                        acceptHeaderValue = "text/turtle",
+                    ),
                     harvestDate = Calendar.getInstance(),
                     forceUpdate = false,
                     runId = "run-1",
@@ -230,11 +230,11 @@ class HarvesterHappyPathTest {
             val report =
                 harvester.harvestInformationModelCatalog(
                     source =
-                        HarvestDataSource(
-                            id = "source-1",
-                            url = "http://localhost:${server.port()}/rdf",
-                            acceptHeaderValue = "text/turtle",
-                        ),
+                    HarvestDataSource(
+                        id = "source-1",
+                        url = "http://localhost:${server.port()}/rdf",
+                        acceptHeaderValue = "text/turtle",
+                    ),
                     harvestDate = Calendar.getInstance(),
                     forceUpdate = false,
                     runId = "run-1",
@@ -280,11 +280,11 @@ class HarvesterHappyPathTest {
             val report =
                 harvester.harvestInformationModelCatalog(
                     source =
-                        HarvestDataSource(
-                            id = "source-1",
-                            url = "http://localhost:${server.port()}/rdf",
-                            acceptHeaderValue = "text/turtle",
-                        ),
+                    HarvestDataSource(
+                        id = "source-1",
+                        url = "http://localhost:${server.port()}/rdf",
+                        acceptHeaderValue = "text/turtle",
+                    ),
                     harvestDate = Calendar.getInstance(),
                     forceUpdate = false,
                     runId = "run-1",
@@ -342,12 +342,12 @@ class HarvesterHappyPathTest {
             val report =
                 harvester.harvestConceptCollection(
                     source =
-                        HarvestDataSource(
-                            id = "source-1",
-                            url = "http://localhost:${server.port()}/rdf",
-                            acceptHeaderValue = "text/turtle",
-                            publisherId = null,
-                        ),
+                    HarvestDataSource(
+                        id = "source-1",
+                        url = "http://localhost:${server.port()}/rdf",
+                        acceptHeaderValue = "text/turtle",
+                        publisherId = null,
+                    ),
                     harvestDate = Calendar.getInstance(),
                     forceUpdate = false,
                     runId = "run-1",
@@ -393,12 +393,12 @@ class HarvesterHappyPathTest {
             val report =
                 harvester.harvestConceptCollection(
                     source =
-                        HarvestDataSource(
-                            id = "source-1",
-                            url = "http://localhost:${server.port()}/rdf",
-                            acceptHeaderValue = "text/turtle",
-                            publisherId = null,
-                        ),
+                    HarvestDataSource(
+                        id = "source-1",
+                        url = "http://localhost:${server.port()}/rdf",
+                        acceptHeaderValue = "text/turtle",
+                        publisherId = null,
+                    ),
                     harvestDate = Calendar.getInstance(),
                     forceUpdate = false,
                     runId = "run-1",
@@ -440,12 +440,12 @@ class HarvesterHappyPathTest {
             val report =
                 harvester.harvestServices(
                     source =
-                        HarvestDataSource(
-                            id = "source-1",
-                            url = "http://localhost:${server.port()}/rdf",
-                            acceptHeaderValue = "text/turtle",
-                            publisherId = null,
-                        ),
+                    HarvestDataSource(
+                        id = "source-1",
+                        url = "http://localhost:${server.port()}/rdf",
+                        acceptHeaderValue = "text/turtle",
+                        publisherId = null,
+                    ),
                     harvestDate = Calendar.getInstance(),
                     forceUpdate = false,
                     runId = "run-1",
@@ -524,12 +524,12 @@ class HarvesterHappyPathTest {
             val report =
                 harvester.harvestServices(
                     source =
-                        HarvestDataSource(
-                            id = "source-1",
-                            url = "http://localhost:${server.port()}/rdf",
-                            acceptHeaderValue = "text/turtle",
-                            publisherId = null,
-                        ),
+                    HarvestDataSource(
+                        id = "source-1",
+                        url = "http://localhost:${server.port()}/rdf",
+                        acceptHeaderValue = "text/turtle",
+                        publisherId = null,
+                    ),
                     harvestDate = Calendar.getInstance(),
                     forceUpdate = false,
                     runId = "run-1",
@@ -620,12 +620,12 @@ class HarvesterHappyPathTest {
             val report =
                 harvester.harvestServices(
                     source =
-                        HarvestDataSource(
-                            id = "source-1",
-                            url = "http://localhost:${server.port()}/rdf",
-                            acceptHeaderValue = "text/turtle",
-                            publisherId = "123",
-                        ),
+                    HarvestDataSource(
+                        id = "source-1",
+                        url = "http://localhost:${server.port()}/rdf",
+                        acceptHeaderValue = "text/turtle",
+                        publisherId = "123",
+                    ),
                     harvestDate = Calendar.getInstance(),
                     forceUpdate = false,
                     runId = "run-1",
@@ -666,12 +666,12 @@ class HarvesterHappyPathTest {
             val report =
                 harvester.harvestEvents(
                     source =
-                        HarvestDataSource(
-                            id = "source-1",
-                            url = "http://localhost:${server.port()}/rdf",
-                            acceptHeaderValue = "text/turtle",
-                            publisherId = null,
-                        ),
+                    HarvestDataSource(
+                        id = "source-1",
+                        url = "http://localhost:${server.port()}/rdf",
+                        acceptHeaderValue = "text/turtle",
+                        publisherId = null,
+                    ),
                     harvestDate = Calendar.getInstance(),
                     forceUpdate = false,
                     runId = "run-1",
@@ -737,11 +737,11 @@ class HarvesterHappyPathTest {
             val report =
                 harvester.harvestDatasetCatalog(
                     source =
-                        HarvestDataSource(
-                            id = "source-1",
-                            url = "http://localhost:${server.port()}/rdf",
-                            acceptHeaderValue = "text/turtle",
-                        ),
+                    HarvestDataSource(
+                        id = "source-1",
+                        url = "http://localhost:${server.port()}/rdf",
+                        acceptHeaderValue = "text/turtle",
+                    ),
                     harvestDate = Calendar.getInstance(),
                     forceUpdate = false,
                     runId = "run-1",
@@ -815,12 +815,12 @@ class HarvesterHappyPathTest {
                         modified = Instant.now(),
                         checksum = "existing-checksum",
                         harvestSource =
-                            HarvestSourceEntity(
-                                id = 2L,
-                                uri = "http://example.org/other-source",
-                                checksum = "other-source-checksum",
-                                issued = Instant.now(),
-                            ),
+                        HarvestSourceEntity(
+                            id = 2L,
+                            uri = "http://example.org/other-source",
+                            checksum = "other-source-checksum",
+                            issued = Instant.now(),
+                        ),
                     ),
                 )
             }

--- a/src/test/kotlin/no/fdk/harvester/harvester/ResourceHarvesterTest.kt
+++ b/src/test/kotlin/no/fdk/harvester/harvester/ResourceHarvesterTest.kt
@@ -177,12 +177,12 @@ class ResourceHarvesterTest {
         orgAdapter: DefaultOrganizationsAdapter,
         resourceEventProducer: ResourceEventProducer,
     ) : ResourceHarvester(
-            harvestSourceRepository,
-            resourceRepository,
-            applicationProperties,
-            orgAdapter,
-            resourceEventProducer,
-        ) {
+        harvestSourceRepository,
+        resourceRepository,
+        applicationProperties,
+        orgAdapter,
+        resourceEventProducer,
+    ) {
         override val harvestConfig =
             ResourceHarvestConfig(
                 harvestDataType = HarvestDataType.dataservice,
@@ -200,10 +200,7 @@ class ResourceHarvesterTest {
 
         override fun memberLinkProperty(): Property = DCAT.service
 
-        override fun listMembers(
-            harvested: Model,
-            sourceURL: String,
-        ): List<MemberRDFModel> = emptyList()
+        override fun listMembers(harvested: Model, sourceURL: String): List<MemberRDFModel> = emptyList()
 
         override fun extractContainers(
             harvested: Model,
@@ -214,9 +211,7 @@ class ResourceHarvesterTest {
 
         override fun isSeparatelyHarvestedMemberType(types: List<RDFNode>): Boolean = types.contains(DCAT.DataService)
 
-        fun testExtractContainerModel(
-            resource: Resource,
-            memberLinkProperty: Property,
-        ): Model = resource.extractContainerModel(memberLinkProperty)
+        fun testExtractContainerModel(resource: Resource, memberLinkProperty: Property): Model =
+            resource.extractContainerModel(memberLinkProperty)
     }
 }

--- a/src/test/kotlin/no/fdk/harvester/kafka/HarvestEventProducerTest.kt
+++ b/src/test/kotlin/no/fdk/harvester/kafka/HarvestEventProducerTest.kt
@@ -83,15 +83,15 @@ class HarvestEventProducerTest {
                 errorMessage = null,
                 changedCatalogs = emptyList(),
                 changedResources =
-                    listOf(
-                        no.fdk.harvester.model
-                            .FdkIdAndUri("fdk-1", "http://example.org/d1"),
-                    ),
+                listOf(
+                    no.fdk.harvester.model
+                        .FdkIdAndUri("fdk-1", "http://example.org/d1"),
+                ),
                 removedResources =
-                    listOf(
-                        no.fdk.harvester.model
-                            .FdkIdAndUri("fdk-2", "http://example.org/d2"),
-                    ),
+                listOf(
+                    no.fdk.harvester.model
+                        .FdkIdAndUri("fdk-2", "http://example.org/d2"),
+                ),
             )
 
         val initiating =

--- a/src/test/kotlin/no/fdk/harvester/kafka/KafkaHarvestEventCircuitBreakerTest.kt
+++ b/src/test/kotlin/no/fdk/harvester/kafka/KafkaHarvestEventCircuitBreakerTest.kt
@@ -488,10 +488,10 @@ class KafkaHarvestEventCircuitBreakerTest {
                 startTime = "2024-01-01T00:00:00+01:00",
                 endTime = "2024-01-01T00:01:00+01:00",
                 removedResources =
-                    listOf(
-                        FdkIdAndUri("resource-1", "http://example.org/resource1"),
-                        FdkIdAndUri("resource-2", "http://example.org/resource2"),
-                    ),
+                listOf(
+                    FdkIdAndUri("resource-1", "http://example.org/resource1"),
+                    FdkIdAndUri("resource-2", "http://example.org/resource2"),
+                ),
             )
 
         every { harvestService.markResourcesAsDeleted(any(), any(), any(), any()) } returns report
@@ -542,18 +542,17 @@ class KafkaHarvestEventCircuitBreakerTest {
         runId: String = "run-123",
         forced: Boolean = false,
         removeAll: Boolean = false,
-    ): HarvestEvent =
-        HarvestEvent
-            .newBuilder()
-            .setPhase(HarvestPhase.INITIATING)
-            .setRunId(runId)
-            .setDataType(dataType)
-            .setDataSourceId(dataSourceId)
-            .setDataSourceUrl(dataSourceUrl)
-            .setAcceptHeader("text/turtle")
-            .setForced(forced)
-            .setRemoveAll(removeAll)
-            .build()
+    ): HarvestEvent = HarvestEvent
+        .newBuilder()
+        .setPhase(HarvestPhase.INITIATING)
+        .setRunId(runId)
+        .setDataType(dataType)
+        .setDataSourceId(dataSourceId)
+        .setDataSourceUrl(dataSourceUrl)
+        .setAcceptHeader("text/turtle")
+        .setForced(forced)
+        .setRemoveAll(removeAll)
+        .build()
 
     private fun createRemovingEvent(
         dataType: DataType,
@@ -561,29 +560,23 @@ class KafkaHarvestEventCircuitBreakerTest {
         dataSourceUrl: String,
         fdkId: String,
         runId: String = "run-123",
-    ): HarvestEvent =
-        HarvestEvent
-            .newBuilder()
-            .setPhase(HarvestPhase.REMOVING)
-            .setRunId(runId)
-            .setDataType(dataType)
-            .setDataSourceId(dataSourceId)
-            .setDataSourceUrl(dataSourceUrl)
-            .setFdkId(fdkId)
-            .build()
+    ): HarvestEvent = HarvestEvent
+        .newBuilder()
+        .setPhase(HarvestPhase.REMOVING)
+        .setRunId(runId)
+        .setDataType(dataType)
+        .setDataSourceId(dataSourceId)
+        .setDataSourceUrl(dataSourceUrl)
+        .setFdkId(fdkId)
+        .build()
 
-    private fun createSuccessReport(
-        dataType: String,
-        sourceId: String,
-        sourceUrl: String,
-    ): HarvestReport =
-        HarvestReport(
-            runId = "run-123",
-            dataSourceId = sourceId,
-            dataSourceUrl = sourceUrl,
-            dataType = dataType,
-            harvestError = false,
-            startTime = "2024-01-01T00:00:00+01:00",
-            endTime = "2024-01-01T00:01:00+01:00",
-        )
+    private fun createSuccessReport(dataType: String, sourceId: String, sourceUrl: String): HarvestReport = HarvestReport(
+        runId = "run-123",
+        dataSourceId = sourceId,
+        dataSourceUrl = sourceUrl,
+        dataType = dataType,
+        harvestError = false,
+        startTime = "2024-01-01T00:00:00+01:00",
+        endTime = "2024-01-01T00:01:00+01:00",
+    )
 }

--- a/src/test/kotlin/no/fdk/harvester/kafka/ResourceEventProducerTest.kt
+++ b/src/test/kotlin/no/fdk/harvester/kafka/ResourceEventProducerTest.kt
@@ -159,10 +159,7 @@ class ResourceEventProducerTest {
         every { kafkaTemplate.send(capture(topics), capture(keys), capture(records)) } returns
             CompletableFuture.completedFuture(mockk<SendResult<String, SpecificRecord>>())
 
-        fun run(
-            dataType: DataType,
-            expectedTopic: String,
-        ) {
+        fun run(dataType: DataType, expectedTopic: String) {
             topics.clear()
             keys.clear()
             records.clear()
@@ -219,10 +216,7 @@ class ResourceEventProducerTest {
         every { kafkaTemplate.send(capture(topics), capture(keys), capture(records)) } returns
             CompletableFuture.completedFuture(mockk<SendResult<String, SpecificRecord>>())
 
-        fun run(
-            dataType: DataType,
-            expectedTopic: String,
-        ) {
+        fun run(dataType: DataType, expectedTopic: String) {
             topics.clear()
             keys.clear()
             records.clear()

--- a/src/test/kotlin/no/fdk/harvester/metrics/HarvestMetricsTest.kt
+++ b/src/test/kotlin/no/fdk/harvester/metrics/HarvestMetricsTest.kt
@@ -53,10 +53,10 @@ class HarvestMetricsTest {
                 startTime = "2024-01-01T00:00:00+01:00",
                 endTime = "2024-01-01T00:01:00+01:00",
                 changedResources =
-                    listOf(
-                        FdkIdAndUri("a", "http://example.org/a"),
-                        FdkIdAndUri("b", "http://example.org/b"),
-                    ),
+                listOf(
+                    FdkIdAndUri("a", "http://example.org/a"),
+                    FdkIdAndUri("b", "http://example.org/b"),
+                ),
                 removedResources = listOf(FdkIdAndUri("c", "http://example.org/c")),
             )
 

--- a/src/test/kotlin/no/fdk/harvester/repository/ResourceRepositoryTest.kt
+++ b/src/test/kotlin/no/fdk/harvester/repository/ResourceRepositoryTest.kt
@@ -125,12 +125,11 @@ class ResourceRepositoryTest {
         assertTrue(found.all { it.fdkId == "fdk-123" })
     }
 
-    private fun createHarvestSource(uri: String): HarvestSourceEntity =
-        HarvestSourceEntity(
-            uri = uri,
-            checksum = "checksum-123",
-            issued = java.time.Instant.now(),
-        )
+    private fun createHarvestSource(uri: String): HarvestSourceEntity = HarvestSourceEntity(
+        uri = uri,
+        checksum = "checksum-123",
+        issued = java.time.Instant.now(),
+    )
 
     private fun createResource(
         uri: String,
@@ -138,15 +137,14 @@ class ResourceRepositoryTest {
         harvestSource: HarvestSourceEntity,
         fdkId: String = "fdk-$uri",
         removed: Boolean = false,
-    ): ResourceEntity =
-        ResourceEntity(
-            uri = uri,
-            type = type,
-            fdkId = fdkId,
-            removed = removed,
-            issued = java.time.Instant.now(),
-            modified = java.time.Instant.now(),
-            checksum = "checksum-$uri",
-            harvestSource = harvestSource,
-        )
+    ): ResourceEntity = ResourceEntity(
+        uri = uri,
+        type = type,
+        fdkId = fdkId,
+        removed = removed,
+        issued = java.time.Instant.now(),
+        modified = java.time.Instant.now(),
+        checksum = "checksum-$uri",
+        harvestSource = harvestSource,
+    )
 }

--- a/src/test/kotlin/no/fdk/harvester/service/HarvestServiceTest.kt
+++ b/src/test/kotlin/no/fdk/harvester/service/HarvestServiceTest.kt
@@ -769,17 +769,16 @@ class HarvestServiceTest {
         assertEquals("fdk-ev", result.removedResources[0].fdkId)
     }
 
-    private fun createReport(dataType: String): HarvestReport =
-        HarvestReport(
-            runId = "run-1",
-            dataSourceId = "ds-1",
-            dataSourceUrl = "http://example.org/source",
-            dataType = dataType,
-            harvestError = false,
-            startTime = "2024-01-01T00:00:00",
-            endTime = "2024-01-01T00:00:01",
-            changedCatalogs = emptyList(),
-            changedResources = emptyList(),
-            removedResources = emptyList(),
-        )
+    private fun createReport(dataType: String): HarvestReport = HarvestReport(
+        runId = "run-1",
+        dataSourceId = "ds-1",
+        dataSourceUrl = "http://example.org/source",
+        dataType = dataType,
+        harvestError = false,
+        startTime = "2024-01-01T00:00:00",
+        endTime = "2024-01-01T00:00:01",
+        changedCatalogs = emptyList(),
+        changedResources = emptyList(),
+        removedResources = emptyList(),
+    )
 }


### PR DESCRIPTION
# Summary 

- Bumps `spring-boot-starter-parent` from 4.0.6 to 4.1.0, which pulls in Tomcat 11.0.22 and fixes the three CRITICAL tomcat-embed-core authentication-bypass CVEs reported by Trivy (was 11.0.21).
- Also brings Spring Framework 7.0.8, Spring Security 7.1.0, spring-data-commons 4.1.0 and Jackson 2.21.4 / 3.1.4.
- Pins `postgresql` to 42.7.13, overriding the 42.7.11 managed by Spring Boot 4.1.0, which is still affected by CVE-2026-54291.
- Adds `.editorconfig` so ktlint has an explicit, checked-in formatting contract instead of relying on defaults.
- Extracts the ktlint plugin version into a `ktlint.version` property, matching how the other versions are declared.
- No source changes were needed: ktlint reports zero violations, and the project does not use `OAuth2ResourceServerProperties`, so the nullable `jwkSetUri` / `issuerUri` change in Spring Framework 7.0.8 does not apply here.
- `mvn clean verify` is green: 169 tests pass, ktlint:check passes and JaCoCo coverage stays above the 90% threshold.
