### PR TITLE
chore: bump base image to alpine 3.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:21-alpine3.18
+FROM amazoncorretto:21-alpine
 
 ARG USER=default
 ENV HOME=/home/$USER
@@ -7,7 +7,7 @@ ENV TZ=Europe/Oslo
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # install sudo as root
-RUN apk update && apk add --no-cache sudo java-snappy
+RUN apk update && apk add --no-cache sudo gcompat
 RUN adduser -D $USER && \
       echo "$USER ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/$USER && \
       chmod 0440 /etc/sudoers.d/$USER
@@ -16,7 +16,4 @@ USER $USER
 WORKDIR $HOME
 
 COPY --chown=$USER:$USER /target/fdk-harvester.jar app.jar
-CMD ["sh", "-c", "java -jar \
-         -Dorg.xerial.snappy.use.systemlib=true \
-         -Dorg.xerial.snappy.lib.path=/usr/lib/libsnappy.so.1 \
-         $JAVA_OPTS app.jar"]
+CMD ["sh", "-c", "java -jar $JAVA_OPTS app.jar"]


### PR DESCRIPTION
# Summary 

- Bump base image from `amazoncorretto:21-alpine3.18` (EOSL, no more security updates) to `amazoncorretto:21-alpine`, which resolves to Alpine 3.24.1 today and picks up newer Alpine releases on rebuild, matching the rest of the FDK fleet.
- A `FROM`-only bump does not work: Alpine 3.24 dropped `java-snappy` and its `java-snappy-native` dependency, so the build fails at `apk add`, and the musl-built `libsnappyjava.so` that `-Dorg.xerial.snappy.use.systemlib=true` loaded is gone.
- Remove both `-Dorg.xerial.snappy` flags and let snappy-java load the native bundled in its own jar. The `lib.path` pin was always a no-op — it expects a directory and pointed at a file.
- Add `gcompat`, since snappy-java 1.1.10.7 ships a glibc-linked x86_64 native and no musl one.
- Verified on `linux/amd64` as the non-root runtime user: image builds, `java -version` runs, Alpine 3.24.1 confirmed inside, and snappy compress/uncompress round-trips. Load-bearing here — this service both produces with `compression.type=snappy` and consumes.