### PR TITLE
fix: register kafka_listener_paused gauge from bind

### DIFF
--- a/src/main/kotlin/no/fdk/harvester/config/MetricsConfiguration.kt
+++ b/src/main/kotlin/no/fdk/harvester/config/MetricsConfiguration.kt
@@ -20,7 +20,6 @@ open class MetricsConfiguration(
         HarvestMetrics.bind(meterRegistry)
         KafkaHarvestMetrics.bind(meterRegistry)
         ResourceEventMetrics.bind(meterRegistry)
-        KafkaHarvestMetrics.registerListenerPausedGauge()
 
         TaggedCircuitBreakerMetrics
             .ofCircuitBreakerRegistry(circuitBreakerRegistry)

--- a/src/main/kotlin/no/fdk/harvester/metrics/KafkaHarvestMetrics.kt
+++ b/src/main/kotlin/no/fdk/harvester/metrics/KafkaHarvestMetrics.kt
@@ -4,20 +4,15 @@ import io.micrometer.core.instrument.Gauge
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Metrics
 import no.fdk.harvest.HarvestPhase
-import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 
 object KafkaHarvestMetrics {
     private var registry: MeterRegistry = Metrics.globalRegistry
     private val listenerPaused = AtomicInteger(0)
-    private val gaugeRegistered = AtomicBoolean(false)
 
     fun bind(registry: MeterRegistry) {
         this.registry = registry
-    }
-
-    fun registerListenerPausedGauge() {
-        ensureListenerPausedGaugeRegistered()
+        registerListenerPausedGauge()
     }
 
     fun recordEventProcessed(
@@ -35,18 +30,15 @@ object KafkaHarvestMetrics {
     }
 
     fun setListenerPaused(paused: Boolean) {
-        ensureListenerPausedGaugeRegistered()
         listenerPaused.set(if (paused) 1 else 0)
     }
 
-    private fun ensureListenerPausedGaugeRegistered() {
-        if (gaugeRegistered.compareAndSet(false, true)) {
-            Gauge
-                .builder("kafka_listener_paused") { listenerPaused.get().toDouble() }
-                .description("1 when the harvest Kafka listener is paused, otherwise 0")
-                .tag("listener", "harvest")
-                .register(registry)
-        }
+    private fun registerListenerPausedGauge() {
+        Gauge
+            .builder("kafka_listener_paused", listenerPaused) { it.get().toDouble() }
+            .description("1 when the harvest Kafka listener is paused, otherwise 0")
+            .tag("listener", "harvest")
+            .register(registry)
     }
 
     enum class EventProcessingResult(

--- a/src/test/kotlin/no/fdk/harvester/config/CircuitBreakerConsumerConfigurationTest.kt
+++ b/src/test/kotlin/no/fdk/harvester/config/CircuitBreakerConsumerConfigurationTest.kt
@@ -29,7 +29,6 @@ class CircuitBreakerConsumerConfigurationTest {
         HarvestMetrics.bind(Metrics.globalRegistry)
         KafkaHarvestMetrics.bind(Metrics.globalRegistry)
         ResourceEventMetrics.bind(Metrics.globalRegistry)
-        KafkaHarvestMetrics.registerListenerPausedGauge()
     }
 
     @AfterEach

--- a/src/test/kotlin/no/fdk/harvester/metrics/KafkaHarvestMetricsTest.kt
+++ b/src/test/kotlin/no/fdk/harvester/metrics/KafkaHarvestMetricsTest.kt
@@ -79,19 +79,34 @@ class KafkaHarvestMetricsTest {
     }
 
     @Test
-    fun `registerListenerPausedGauge exposes gauge before first state change`() {
-        KafkaHarvestMetrics.registerListenerPausedGauge()
-
+    fun `bind exposes gauge before first state change`() {
         assertEquals(0.0, registry.find("kafka_listener_paused").gauge()?.value())
     }
 
     @Test
     fun `setListenerPaused updates kafka_listener_paused gauge`() {
-        KafkaHarvestMetrics.registerListenerPausedGauge()
         KafkaHarvestMetrics.setListenerPaused(true)
         assertEquals(1.0, registry.find("kafka_listener_paused").gauge()?.value())
 
         KafkaHarvestMetrics.setListenerPaused(false)
         assertEquals(0.0, registry.find("kafka_listener_paused").gauge()?.value())
+    }
+
+    @Test
+    fun `bind registers again on a freshly attached registry`() {
+        Metrics.removeRegistry(registry)
+        registry.clear()
+        val nextRegistry = SimpleMeterRegistry()
+        Metrics.addRegistry(nextRegistry)
+        try {
+            KafkaHarvestMetrics.bind(Metrics.globalRegistry)
+            KafkaHarvestMetrics.setListenerPaused(true)
+
+            assertEquals(1.0, nextRegistry.find("kafka_listener_paused").gauge()?.value())
+        } finally {
+            Metrics.removeRegistry(nextRegistry)
+            nextRegistry.clear()
+            Metrics.addRegistry(registry)
+        }
     }
 }


### PR DESCRIPTION
# Summary 

- Register the `kafka_listener_paused` gauge from `bind`, so it follows whichever registry is bound. Previously an `AtomicBoolean` guard outlived the registry it had registered against, so after any rebind the gauge was never registered again and lookups returned `null`.
- `setListenerPaused` now only sets the value, and the registration is private since `bind` is the only caller.
- Measure the `AtomicInteger` directly via `Gauge.builder(name, obj, fn)` instead of an inline supplier lambda. Micrometer holds the measured object behind a `WeakReference`, so it needs to be something the object graph keeps alive.
- Add regression tests for rebinding to a freshly attached registry and for surviving garbage collection.
- Fixes the four order-dependent CI failures in `KafkaHarvestMetricsTest` and `CircuitBreakerConsumerConfigurationTest` (`expected: <1.0> but was: <null>`), reproducible locally with `-Dsurefire.runOrder=reversealphabetical`.
