### PR TITLE
fix: bump jena 6.2.0 and httpcore5 5.4.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,10 +35,11 @@
         <kotlin.version>2.3.21</kotlin.version>
         <ktlint.version>3.7.1</ktlint.version>
         <testcontainers.version>2.0.5</testcontainers.version>
-        <jena.version>6.0.0</jena.version>
+        <jena.version>6.2.0</jena.version>
         <avro.version>1.12.1</avro.version>
         <confluent.version>8.2.0</confluent.version>
         <resilience4j.version>2.4.0</resilience4j.version>
+        <httpcore5.version>5.4.3</httpcore5.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
# Summary 

- Bump `jena.version` from 6.0.0 to 6.2.0 to resolve the Trivy finding on `org.apache.thrift:libthrift`, which Jena pins transitively. `libthrift` now resolves to 0.24.0 (was 0.22.0); Jena 6.1.0 still pins 0.22.0, so 6.2.0 is the lowest version that clears it.
- Add an `<httpcore5.version>5.4.3</httpcore5.version>` override. `httpclient5` was already at 5.6.3, but Spring Boot 4.1.0 manages `httpcore5` and `httpcore5-h2` directly in its BOM at 5.4.2, and dependencyManagement beats the version `httpclient5-parent` declares transitively — so they were still resolving to 5.4.2 (compile scope, i.e. shipped). Both now resolve to 5.4.3.
- Full `mvn clean verify` passes: 170/170 tests green, and green again with `-Dsurefire.runOrder=reversealphabetical`. 170 matches the count on `main`, so no test was lost.
- No source changes and no new Jena deprecation warnings.
